### PR TITLE
DS-3699 small fix to align the actual implementation with the contract

### DIFF
--- a/authorities.md
+++ b/authorities.md
@@ -45,23 +45,23 @@ sample for an authority
 		{
 		  "id": "rp00001",
 		  "display": "Surname, Lastname",
-		  "count": 19,
 		  "otherInformation": 
 		  	{
 		    	ORCID: "0000-0000-0000-0000"
 		      	affiliation: "University of Sample",
-		      	biography: "..."
+		      	biography: "...",
+		      	"count": 19
 		    }
 	    },
 	    {
 		  "id": "rp00002",
 		  "display": "Other, Researcher",
-		  "count": 3,
 		  "otherInformation": 
 		  	{
 		    	"ORCID": "0000-0000-0000-0000"
 		      	"affiliation": "My University",
-		      	"biography": "..."
+		      	"biography": "...",
+		      	"count": 3
 		    }
 	    },
 }
@@ -74,19 +74,19 @@ sample for a hierarchical authority  (srsc)
 		{
 		  "id": "SCB110"
 		  "display": "History of religion",
-		  "count": 19,
 		  "otherInformation": 
 		  	{
-		    	"note": "Religionshistoria"
+		    	"note": "Religionshistoria",
+		    	"count": 19
 		    }
 	    },
 	    {
 		  "id": "VR110103"
 		  "display": "Other, Researcher",
-		  "count": 3,
 		  "otherInformation": 
 		  	{
-		    	"note": "Kyrkovetenskap"
+		    	"note": "Kyrkovetenskap",
+		    	"count": 3
 		    }
 	    },
 	    ...

--- a/endpoints.md
+++ b/endpoints.md
@@ -19,9 +19,9 @@
 ## Endpoints Under Development
 
 * [/api/discover/search](search-endpoint.md)
-* [/api/config/submission-definitions](submission-definitions.md)
-* [/api/config/submission-sections](submission-sections.md)
-* [/api/config/submission-forms](submission-forms.md)
+* [/api/config/submissiondefinitions](submissiondefinitions.md)
+* [/api/config/submissionsections](submissionsections.md)
+* [/api/config/submissionforms](submissionforms.md)
 * [/api/integration/authorities](authorities.md)
  
 ## Proposed Endpoints

--- a/submissiondefinitions.md
+++ b/submissiondefinitions.md
@@ -4,14 +4,14 @@
 A submission-definition is defined globally or per collection. It defines an overall submission process, consisting of a series of "sections" (previously than DSpace 7 known as Steps).
 
 ## Main Endpoint
-**/api/config/submission-definitions**   
+**/api/config/submissiondefinitions**   
 
 Provide access to the configured submission definitions. It returns the list of existent submission-definitions.
 
 Example: to be provided
 
 ## Single Submission-Definition
-**/api/config/submission-definitions/<:definition-name>**
+**/api/config/submissiondefinitions/<:definition-name>**
 
 Provide detailed information about a specific submission-definition. The JSON response document is as follow
 ```json
@@ -29,17 +29,17 @@ Exposed links:
 
 ### Search methods
 #### findByCollection
-**/api/config/submission-definitions/search/findByCollection?uuid=<:collection-uuid>**
+**/api/config/submissiondefinitions/search/findByCollection?uuid=<:collection-uuid>**
 
 It returns the submission definition that apply to a specific collection eventually fallback to the default configuration 
 
 ### Linked entities
 #### collections
-**/api/config/submission-definitions/<:definition-name>/collections**
+**/api/config/submissiondefinitions/<:definition-name>/collections**
 
 It returns the list of collection that make an explicit use of the submission-definition. If a collection doesn't specify the submission-definition to be used the default mapping apply but this collection is not included in the list returned by this method
 
 #### sections
-**/api/config/submission-definitions/<:definition-name>/sections**
+**/api/config/submissiondefinitions/<:definition-name>/sections**
 
-It returns the list of submission-sections used in the submission-definition, see [submission-sections.md](submission-sections.md#Single Submission-Section)
+It returns the list of submission-sections used in the submission-definition, see [submissionsections.md](submissionsections.md#Single Submission-Section)

--- a/submissionforms.md
+++ b/submissionforms.md
@@ -4,20 +4,21 @@
 A submission-form represents a single data entry form, associated with a submission section. It is configurable, and consists of one or more data entry fields. In DSpace 6 and below, this concept was called an "input-form" and was configured via input-forms.xml.
 
 ## Main Endpoint
-**/api/config/submission-forms**   
+**/api/config/submissionforms**   
 
 Provide access to the configured submission-forms. It returns the list of existent submission-forms.
-Please note that from DSpace 7 the submission-form concept has been introduced splitting the previous configuration file named input-forms.xml by page. Each submission-form describes a single page of inputs, combining different pages together is done with the [submission-definition](submission-definitions.md), aka the item-submission.xml configuration file 
+Please note that from DSpace 7 the submission-form concept has been introduced splitting the previous configuration file named input-forms.xml by page. Each submission-form describes a single page of inputs, combining different pages together is done with the [submission-definition](submissiondefinitions.md), aka the item-submission.xml configuration file 
 
 Example: to be provided
 
 ## Single Submission-Form 
-**/api/config/submission-forms/<:form-name>**
+**/api/config/submissionforms/<:form-name>**
 
 Provide detailed information about a specific input-form. The JSON response document is as follow
 ```json
 {
   "name": "traditional-page1",
+  "type": "submissionform",
   "fields": [
   		{
   			label: "Authors",

--- a/submissionsections.md
+++ b/submissionsections.md
@@ -4,14 +4,14 @@
 A submission-section represents a single section in the submission process. Depending on its type, it may include a configurable input form (if type='submission-form'). However, not all sections are currently configurable, and other types of steps include file upload, embargo/access rights, creative commons licensing, etc.
 
 ## Main Endpoint
-**/api/config/submission-sections**   
+**/api/config/submissionsections**   
 
 Provide access to the configured submission sections. It returns the list of existent submission-sections.
 
 Example: to be provided
 
 ## Single Submission-Definition
-**/api/config/submission-sections/<:section-name>**
+**/api/config/submissionsections/<:section-name>**
 
 Provide detailed information about a specific submission-section. The JSON response document is as follow
 ```json
@@ -19,10 +19,11 @@ Provide detailed information about a specific submission-section. The JSON respo
   	id: "id-of-the-submission-form-page",
   	header: "First page",
   	mandatory: true,
-  	type: "submission-form",
+  	sectionType: "submission-form",
   	scope: null,
+  	type: "submissionsection",
   	_links: {
-  		"config" : "<dspace-url>/config/submission-forms/<:id-of-the-submission-form-page>" 
+  		"config" : "<dspace-url>/config/submissionforms/<:id-of-the-submission-form-page>" 
   	}
 }
 ```


### PR DESCRIPTION
As result of the implementation proposed in https://github.com/DSpace/DSpace/pull/1852 some small changes to the contract are required. They are needed to keep the contract uniform between different endpoints and make the implementation easier

- removed the minus in the endpoint urls, all the endpoints are lowercase
- the type attribute is reserved for the name of the REST resource.
- introduced the sectionType
- count goes in the extraInformation section of the authority entry