### PR TITLE
DS-3759 the patch method for the workspaceitem

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Returns whether the item resource is available.
 Replaces the state of the target resource with the supplied request body.
 
 - PATCH
-Similar to PUT but partially updating the resources state. We adhere to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902)
+Similar to PUT but partially updating the resources state. We adhere to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) see the [General rules for the Patch operation](patch.md) for more details.
 
 - DELETE
 Deletes the resource exposed.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Returns whether the item resource is available.
 Replaces the state of the target resource with the supplied request body.
 
 - PATCH
-Similar to PUT but partially updating the resources state.
+Similar to PUT but partially updating the resources state. We adhere to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902)
 
 - DELETE
 Deletes the resource exposed.

--- a/collections.md
+++ b/collections.md
@@ -1,0 +1,126 @@
+# Collections Endpoints
+[Back to the list of all defined endpoints](endpoints.md)
+
+## Main Endpoint
+**/api/core/collections**   
+
+Provide access to the list of collections (DBMS based).
+
+Example: <http://dspace7.4science.it/dspace-spring-rest/#/dspace-spring-rest/api/core/collections>
+
+## Single Collection
+**/api/core/collections/<:uuid>**
+
+Provide detailed information about a specific community. The JSON response document is as follow
+```json
+{
+  "uuid": "1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb",
+  "name": "Collection of Sample Items",
+  "handle": "10673/2",
+  "metadata": [
+    {
+      "key": "dc.provenance",
+      "value": "This field is for private provenance information. It is only visible to Administrative users and is not displayed in the user interface by default.",
+      "language": null
+    },
+    {
+      "key": "dc.rights.license",
+      "value": "",
+      "language": null
+    },
+    {
+      "key": "dc.description",
+      "value": "<p>This is a <em>DSpace Collection</em> which contains sample DSpace Items.</p>\r\n<p><strong>Collections in DSpace may only contain Items.</strong></p>\r\n<p>This particular Collection has its own logo (the <a href=\"http://www.opensource.org/\">Open Source Initiative</a> logo).</p>\r\n<p>This introductory text is editable by System Administrators, Community Administrators (of a parent Community) or Collection Administrators (of this Collection).</p>",
+      "language": null
+    },
+    {
+      "key": "dc.description.abstract",
+      "value": "This collection contains sample items.",
+      "language": null
+    },
+    {
+      "key": "dc.description.tableofcontents",
+      "value": "<p>This is the <strong>news</strong> section for this Collection. System Administrators, Community Administrators (of a parent Community) or Collection Administrators (of this Collection) can edit this News field.</p>",
+      "language": null
+    },
+    {
+      "key": "dc.rights",
+      "value": "<p><em>If this collection had a specific copyright statement, it would be placed here.</em></p>",
+      "language": null
+    },
+    {
+      "key": "dc.title",
+      "value": "Collection of Sample Items",
+      "language": null
+    }
+  ],
+  "type": "collection"
+}
+```
+
+Exposed links:
+* logo: link to the bitstream that represent the collection's logo
+* license: link to the license template used by the collection
+* defaultAccessConditions: link to the resource policies applied by default to new submissions in the collection
+
+## Linked entities
+### Logo
+**/api/core/collections/<:uuid>/logo**
+
+Example: <https://dspace7.4science.it/dspace-spring-rest/#https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb/logo>
+
+[It returns the bitstream representing the logo of this collection. See the bitstream endpoint for more info](bitstreams.md#Single Bitstream)
+
+### License
+**/api/core/collections/<:uuid>/license**
+
+Return information about the license template in use by the collection. The json representation is as follow
+```json
+{
+  "custom": false,
+  "text": "NOTE: PLACE YOUR OWN LICENSE HERE\nThis sample license is provided for informational purposes only.\n\nNON-EXCLUSIVE DISTRIBUTION LICENSE\n\nBy signing and submitting this license, you (the author(s) or copyright\nowner) grants to DSpace University (DSU) the non-exclusive right to reproduce,\ntranslate (as defined below), and/or distribute your submission...."
+}
+```
+
+* custom (**READ-ONLY**): can be true or false. True means that a custom license has been set for the collection otherwise the site license template is used and returned in the text attribute
+* text: contains the textual value of the license template to use for submission in the collection
+
+### Default Access Conditions
+**/api/core/collections/<:uuid>/defaultAccessConditions**
+
+It returns the resource policies applied by default to new submissions in the collection. They are the DEFAULT\_BITSTREAM\_READ policies of the collection
+
+The json representation is as follow
+```json
+{
+  "_embedded": {
+    "resourcePolicies": [
+      {
+        "id": 2844,
+        "name": null,
+        "groupUUID": "11cc35e5-a11d-4b64-b5b9-0052a5d15509",
+        "action": "DEFAULT\_BITSTREAM\_READ",
+        "type": "resourcePolicy",
+        "_links": {
+          "self": {
+            "href": "https://dspace7.4science.it/dspace-spring-rest/api/authz/resourcePolicies/2844"
+          }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/5ad50035-ca22-4a4d-84ca-d5132f34f588/defaultAccessConditions"
+    }
+  },
+  "page": {
+    "size": 20,
+    "totalElements": 1,
+    "totalPages": 1,
+    "number": 0
+  }
+}
+```
+see also the [ResourcePolicies endpoint](resourcepolicies.md)
+

--- a/endpoints.md
+++ b/endpoints.md
@@ -13,25 +13,29 @@
 * /api/core/metadataschemas
 * /api/core/epersons
 * /api/core/groups
-* /api/core/{model}/search
-* [/api/discover/browses](browses.md)
-
-## Endpoints Under Development
-
-* [/api/discover/search](search-endpoint.md)
+* [/api/core/{model}/search](search-rels.md)
 * [/api/config/submissiondefinitions](submissiondefinitions.md)
 * [/api/config/submissionsections](submissionsections.md)
 * [/api/config/submissionforms](submissionforms.md)
+* [/api/discover/browses](browses.md)
+* [/api/integration/authorities](authorities.md)
+
+## Endpoints Under Development/Discussion
+* [/api/discover/search](search-endpoint.md)
+* [/api/config/submissionuploads](submissionforms.md)
 * [/api/integration/authorities](authorities.md)
 * [/api/submission/workspaceitems](workspaceitems.md)
+* /api/authn/login
+* /api/authn/logout
+* /api/authn/status
+* /api/authz/resourcepolicies
  
-## Proposed Endpoints
+## Other Endpoints (raw list)
 * /api/authorize/(dso)
 * /api/curate
 * /api/export
 * /api/app/bulkmetadataedit
 * /api/statistics/(dso)
-* /api/authority
 * /api/configuration
   * return relevant configuration values to the client
     * DSpace version

--- a/patch.md
+++ b/patch.md
@@ -1,0 +1,37 @@
+# General rules for the Patch operation
+[Back to the index](README.md)
+
+The PATCH method expects a JSON body according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902)
+
+Each successful Patch operation will return a **HTTP 200 CODE** with the new state of the patched resource as body similar to what is returned for a GET request. 
+
+### Add
+The add operation is expected to be supported by all the endpoints that implement the Patch method for all the json path not flagged as **READ-ONLY**.
+
+Please note that according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) a subsequent add operation on an already set attribute have the effect to replace the previous value.
+
+This use of the add operation to replace a value could be counter intuitive but it is done according to the [RFC section 4.1](https://tools.ietf.org/html/rfc6902#section-4.1)
+> If the target location specifies an object member that does exist, that member's value is replaced.
+
+### Remove
+The remove operation is expected to be supported by all the endpoints that implement the Patch method for all the json path not flagged as **READ-ONLY**.
+Support for remove operation is expected to be provided also to the array index path level for each attribute or list where position is meaningful. This include for instance the metadata values or the uploaded bitstreams so that an author or a bitstrems can be removed individually.  
+The path specified will be nullified deleting all the children objects if any.
+
+### Replace
+The replace operation is expected to be supported by all the endpoints that implement the Patch method for all the json path not flagged as **READ-ONLY**.
+
+The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation without a previous value will return an error. See the [general errors on PATCH requests section](patch.md#Errors)
+
+### Move
+The move operation should be supported on array attributes or linked list where the position is meaningful. This include for instance the metadata values so that authors can be reordered or the list of bitstrems.  
+
+### Test & copy
+No plan to implement the test and copy operations at the current stage
+
+## Error codes
+* **405 Method Not Allowed** - if the PATCH method is not implemented
+* **415 Unsupported Media Type** - if the PATCH method is called without the JSON Patch Media Type that is application/json-patch+json
+* **400 Bad Request** - Malformed patch document (taken from rfc5789#section-2.2) - When the server determines that the patch document provided by the client is not properly formatted, it SHOULD return a 400 (Bad Request) response. The definition of badly formatted depends on the patch document chosen. 
+* **422 Unprocessable Entity** - Unprocessable request:  Can be specified with a 422 (Unprocessable Entity) response ([RFC4918], Section 11.2) when the server understands the patch document and the syntax of the patch document appears to be valid, but the server is incapable of processing the request.  This might include attempts to modify a resource in a way that would cause the resource to become invalid; A response json object should be returned with more details about the exception t.b.d (i.e. the idx of the patch operation that fail, detail about the failure on execution such as wrong idx in an array path, unsupported patch operation, etc.)
+  

--- a/resourcepolicies.md
+++ b/resourcepolicies.md
@@ -6,8 +6,6 @@
 
 As we don't have yet an use case to iterate over all the existent resource policies the main endpoint is not implemented and a 405 error code is returned according to our [general error response codes](README.md#Error codes).
 
-Example: <http://dspace7.4science.it/dspace-spring-rest/#/dspace-spring-rest/api/core/collections>
-
 ## Single Resource Policy
 **/api/authz/resourcepolicies/<:id>**
 

--- a/resourcepolicies.md
+++ b/resourcepolicies.md
@@ -1,0 +1,45 @@
+# Resource Policies Endpoints
+[Back to the list of all defined endpoints](endpoints.md)
+
+## Main Endpoint
+**/api/authz/resourcepolicies**   
+
+As we don't have yet an use case to iterate over all the existent resource policies the main endpoint is not implemented and a 405 error code is returned according to our [general error response codes](README.md#Error codes).
+
+Example: <http://dspace7.4science.it/dspace-spring-rest/#/dspace-spring-rest/api/core/collections>
+
+## Single Resource Policy
+**/api/authz/resourcepolicies/<:id>**
+
+Provide detailed information about a specific resource policy. The JSON response document is as follow
+```json
+{
+  "id": 2844,
+  "name": null,
+  "description": null,
+  "resourceType": "TYPE_SUBMISSION",
+  "action": "DEFAULT_BITSTREAM_READ",
+  "type": "resourcePolicy"
+}
+```
+
+Exposed links:
+* eperson: link to the eperson that have permission grant by the policy
+* group: link to the group that have permission grant by the policy
+* resource: link to the resource subject to the policy
+
+## Linked entities
+### EPerson
+**/api/authz/resourcepolicies/<:id>/eperson**
+
+t.b.d
+
+### Group
+**/api/authz/resourcepolicies/<:id>/group**
+
+t.b.d
+
+### Resource
+**/api/authz/resourcepolicies/<:id>/resource**
+
+t.b.d

--- a/resourcepolicies.md
+++ b/resourcepolicies.md
@@ -15,8 +15,8 @@ Provide detailed information about a specific resource policy. The JSON response
   "id": 2844,
   "name": null,
   "description": null,
-  "resourceType": "TYPE_SUBMISSION",
-  "action": "DEFAULT_BITSTREAM_READ",
+  "policyType": "TYPE_SUBMISSION",
+  "action": "READ",
   "type": "resourcePolicy"
 }
 ```

--- a/search-rels.md
+++ b/search-rels.md
@@ -1,29 +1,14 @@
-# Endpoint Searches and Endpoint Relationships
+# Endpoint' Search methods
 [REST Overview Documentation](README.md)
 
 Resources collection should expose search methods to return specific subsets depending on the user requirements. Such as the items from a specific submitter, the top level communities, etc.
 All these methods should be exposed under <resources-collection-endpoint>/search/<method-name> at <resources-collection-endpoint>/search a HAL document should list all the available search methods for the resources collection
 
-**Please note that the Discovery search is a completely separate topic**
+**Please note that the [Discovery search](search-endpoint.md) is a completely separate topic**
 
-## Available Search
-not yet
-
-## Under Development
-* /communities/search/top - list top level communities (shoud this be /core/search/top-communities)
-
-## Available Relationships
-* /communities/:uuid/collections
-* /communities/:uuid/logo
-* /collections/:uuid/logo
+## Endpoint that have Search methods
+* /core/communities
+* /config/submissiondefinitions
 
 ## Under Development
-* /community/(id)/subCommunities
-
-## Proposed Ideas
-* /communities/:uuid/parentCommunity
-* /collections/:uuid/parentCommunity
-* /collections/:uuid/workflow
-* /collections/:uuid/templateitem
-
-## Rejected Ideas
+* /submission/workspaceitems

--- a/submissionsection-types.md
+++ b/submissionsection-types.md
@@ -8,7 +8,7 @@ sectionType | configuration endpoint | data representation
 collection | n/a | ```json { collection: 'uuid-of-the-collection'}```
 submission-form | [/config/submissionforms](submissionforms.md) | [example](workspaceitem-data-metadata.md)
 upload | [/config/submissionuploads](submissionuploads.md) | [example](workspaceitem-data-upload.md)
-license | (it is retrieved from the collection following the *license* link](collections.md) | [example](workspaceitem-data-license.md)
+license | (it is retrieved from the collection following the *license* link](collections.md#License) | [example](workspaceitem-data-license.md)
 cclicense | t.b.d | t.b.d
 access | t.b.d | t.b.d
 

--- a/submissionsection-types.md
+++ b/submissionsection-types.md
@@ -8,7 +8,7 @@ sectionType | configuration endpoint | data representation
 collection | n/a | ```json { collection: 'uuid-of-the-collection'}```
 submission-form | [/config/submissionforms](submissionforms.md) | [example](workspaceitem-data-metadata.md)
 upload | [/config/submissionuploads](submissionuploads.md) | [example](workspaceitem-data-upload.md)
-license | (it is retrieved from the collection following the *license* link](collections.md#License) | [example](workspaceitem-data-license.md)
+license | [it is retrieved from the collection following the *license* link](collections.md#License) | [example](workspaceitem-data-license.md)
 cclicense | t.b.d | t.b.d
 access | t.b.d | t.b.d
 

--- a/submissionsection-types.md
+++ b/submissionsection-types.md
@@ -1,0 +1,16 @@
+# Submission Section Types
+[Submission-Sections Endpoints](submissionsections.md)
+
+The following table summarize for each sectionType available out-of-box in DSpace 7 the endpoint used to retrieve the extra configuration where needed and the link to the documentation about the data representation returned in the workspaceitem
+
+sectionType | configuration endpoint | data representation
+------------ | ------------- | -------------
+collection | n/a | ```json { collection: 'uuid-of-the-collection'}```
+submission-form | [/config/submissionforms](submissionforms.md) | [example](workspaceitem-data-metadata.md)
+upload | [/config/submissionuploads](submissionuploads.md) | [example](workspaceitem-data-upload.md)
+license | (it is retrieved from the collection following the *license* link](collections.md) | [example](workspaceitem-data-license.md)
+cclicense | t.b.d | t.b.d
+access | t.b.d | t.b.d
+
+n/a --> not applicable. The sectionType doesn't require/support any extra configuration
+t.b.d. --> to be defined. We still need to discuss that

--- a/submissionsections.md
+++ b/submissionsections.md
@@ -2,6 +2,7 @@
 [Back to the list of all defined endpoints](endpoints.md)
 
 A submission-section represents a single section in the submission process. Depending on its type, it may include a configurable input form (if type='submission-form'). However, not all sections are currently configurable, and other types of steps include file upload, embargo/access rights, creative commons licensing, etc.
+A list of the [available sectionType is provided here](submissionsection-types.md)
 
 ## Main Endpoint
 **/api/config/submissionsections**   
@@ -31,10 +32,11 @@ Provide detailed information about a specific submission-section. The JSON respo
 * the *header* attribute is the label or the i18n key to use to present the section to the user
 * the *mandatory* attribute defines if the section MUST be used by each submission. Otherwise, the user is allowed to enable/disable the section interacting with the workspaceitem
 * the *scope* attribute can be null or one of the values: workflow or submission. A value other than *null* mean that the section will be only available during the specified phase 
-* the *sectionType* attribute defines the kind of section that the UI will need to use to interact with the data.
+* the *sectionType* attribute defines the kind of section that the UI will need to use to interact with the data. See the [documentation about the available values for sectionType provided here](submissionsection-types.md)
 
 
 ## Linked Entities
 ### config
 
-It returns the endpoint to use to access a detailed, panel-type dependend, configuration to be used in the panel. Such as the list of fields to include in a form based panel, the upload and access condition options for an upload panel, etc.
+It returns the endpoint to use to access a detailed, sectionType dependent, configuration to be used in the panel. Such as the list of fields to include in a form based panel, the upload and access condition options for an upload panel, etc.
+See the [documentation about the available values for sectionType provided here](submissionsection-types.md)

--- a/submissionuploads.md
+++ b/submissionuploads.md
@@ -51,6 +51,8 @@ The attributes of the objects in the accessConditionOptions arrays are as follow
 * If there is a *hasStartDate* attribute and it is true, the access condition to be applied requires to specify a startDate that must be less or equal than the value of the *maxStartDate* attribute (if null any date is acceptable)
 * If there is a *hasEndDate* attribute and it is true, the access condition to be applied requires to specify an endDate that must be less or equal than the value of the *maxEndDate* attribute (if null any date is acceptable). If a startDate is supplied the endDate must be greater than the startDate
 
+a null value for the accessConditionOptions attribute mean that the upload step doens't allow the user to set a policy for the file. The file will get only the policies inherited from the collection.
+
 Exposed links:
 * metadata: it is a link to the submission-form to use for the files metadata
 

--- a/submissionuploads.md
+++ b/submissionuploads.md
@@ -1,0 +1,60 @@
+# SubmissionUploads Endpoints
+[Back to the list of all defined endpoints](endpoints.md)
+
+The proposed structure is derived from the configuration options already available in DSpace 6 and below. In the first implementation, a single configuration named *default* is expected as these configurations were set at the site level. Introducing an endpoint to manage a collection of configurations we open the door to future extension where different setups can be used for different kind of submissions (theses, technical reports, journal articles, etc.)
+
+## Main Endpoint
+**/api/config/submissionuploads**   
+
+Provide access to the existent configurations for the submission upload. It returns the list of existent SubmissionUploadConfig.
+The SubmissionUploadConfig aggregates in a single place the configuration needed to the upload section such as the max allowed size for the files, the access condition options, etc.
+
+Example: to be provided
+
+## Single Submission-Form 
+**/api/config/submissionuploads/<:upload-name>**
+
+*:upload-name* is initially hard-coded to *default*
+
+Provide detailed information about a specific input-form. The JSON response document is as follow
+```json
+{
+  "id": "default",
+  "required": true,
+  "max-size": 536870912,
+  "accessConditionOptions": [
+		{
+ 			"name": "openaccess"
+		},
+		{
+ 			"name": "administrator"
+		},  	 			
+		{
+ 			"name": "embargo",
+ 			"selectGroupUUID": "1faf7c51-2a14-4826-b0b1-f1c1d2d82dd7",
+ 			"hasStartDate": true,
+ 			"maxStartDate": "2018-06-24T00:40:54.970+0000"
+		},
+		{
+ 			"name": "lease",
+ 			"selectGroupUUID": "38ecd5ae-af12-4144-a276-81532e1679f8",
+ 			"hasEndDate": true,
+ 			"maxEndDate": "2017-12-24T00:40:54.970+0000"
+		}
+  ]
+}
+
+```
+The attributes of the objects in the accessConditionOptions arrays are as follow:
+* The *name* attribute is an identifier that can be used by the REST client (the UI) to present the different options to the user, maybe translating it in an human readable format using i18n, and by the backend to create the ResourcePolicy to apply to the uploaded file using and validating the additional inputs provided by the user where required.
+* If there is a *selectGroupUUID* attribute, the access condition to be applied requires to specify a group that need to be a direct descending of the group with the uuid specified by the attribute.
+* If there is a *hasStartDate* attribute and it is true, the access condition to be applied requires to specify a startDate that must be less or equal than the value of the *maxStartDate* attribute (if null any date is acceptable)
+* If there is a *hasEndDate* attribute and it is true, the access condition to be applied requires to specify an endDate that must be less or equal than the value of the *maxEndDate* attribute (if null any date is acceptable). If a startDate is supplied the endDate must be greater than the startDate
+
+Exposed links:
+* metadata: it is a link to the submission-form to use for the files metadata
+
+### Linked entities
+#### metadata
+**/api/confg/submissionupload/:upload-name/metadata**
+The [submission-form](submissionforms.md) used for the metadata of the files

--- a/workspaceitem-data-license.md
+++ b/workspaceitem-data-license.md
@@ -1,0 +1,171 @@
+# WorkspaceItem data of license sectionType
+[Back to the definition of the workspaceitems endpoint](workspaceitems.md)
+
+The section data represent the data about the granted deposit license
+
+```json
+{
+  	"url": "https://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/004a297e-fd06-4662-ae51-73e4b7c165c8/content",
+    "acceptanceDate": "2017-11-20T10:32:42Z"
+}
+```
+
+* url (**READ-ONLY**): the URL where the accepted license is visible
+* acceptanceDate: the timestamp of the acceptance as recorded in the dcterms:dataAccepted metadata of the license bitstream. For license accepted before than DSpace7 the acceptanceDate will be *null* 
+
+## Patch operations
+The PATCH method expects a JSON body according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902)
+
+Each successful Patch operation will return a HTTP 200 CODE with the new workspaceitem as body 
+
+### Add
+To accept a license the timestamp of the acceptance the client must send a JSON Patch ADD operation as follow
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/acceptanceDate", "value": "YYYY-MM-DDTHH:MM:SSZ"}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+for example, starting with the following document  
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+			{
+			  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+			  "dc.contributor.author" : [
+			  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600}
+			  ]
+			},
+		"license":
+			{
+			  	"url": null,
+			    "acceptanceDate": null
+			}
+		...
+	},
+	...
+}	
+```
+
+the following request 
+`curl --data '{[ { "op": "add", "path": "/sections/license/acceptanceDate", "value": "2017-11-20T10:32:42Z"}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+will result in
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+			{
+			  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+			  "dc.contributor.author" : [
+			  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600}
+			  ]
+			},
+		"license":
+			{
+			  	"url": "https://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/004a297e-fd06-4662-ae51-73e4b7c165c8/content",
+			    "acceptanceDate": "2017-11-20T10:32:42Z"
+			}
+		...
+	},
+	...
+}	
+```
+
+Please note that according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) a subsequent add operation on the acceptanceDate will have the effect to replace the previous granted license with a new one.
+
+This use of the add operation to replace the license could be counter intuitive but it is done according to the [RFC section 4.1](https://tools.ietf.org/html/rfc6902#section-4.1)
+> If the target location specifies an object member that does exist, that member's value is replaced.
+
+### Remove
+It is possible to remove a previous grant license 
+`curl --data '{[ { "op": "remove", "path": "/sections/license/acceptanceDate"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+trasforming
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+			{
+			  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+			  "dc.contributor.author" : [
+			  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600}
+			  ]
+			},
+		"license":
+			{
+			  	"url": "https://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/004a297e-fd06-4662-ae51-73e4b7c165c8/content",
+			    "acceptanceDate": "2017-11-20T10:32:42Z"
+			}
+		...
+	},
+	...
+}	
+```
+
+back in
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+			{
+			  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+			  "dc.contributor.author" : [
+			  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600}
+			  ]
+			},
+		"license":
+			{
+			  	"url": null,
+			    "acceptanceDate": null
+			}
+		...
+	},
+	...
+}	
+```
+
+This will works also in the case where the license was granted (url != null) but the acceptanceDate was not recorded (< DSpace 7).
+
+### Replace
+The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation without a previous accepted license must return an error. See [general errors on PATCH requests](patch.md)
+
+`curl --data '{[ { "op": "replace", "path": "/sections/license/acceptanceDate", "value": "2017-11-21T12:31:14Z"}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+			{
+			  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+			  "dc.contributor.author" : [
+			  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600}
+			  ]
+			},
+		"license":
+			{
+			  	"url": "https://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/new-uuid/content",
+			    "acceptanceDate": "2017-11-21T12:31:14Z"
+			}
+		...
+	},
+	...
+}	
+```
+Please note that a new bitstream license will be added to the item and the previous license deleted, this mean that the *url* attribute will change accordly.
+ 
+### Move, Test & copy
+No plan to implement the move, test and copy operations at the current stage

--- a/workspaceitem-data-metadata.md
+++ b/workspaceitem-data-metadata.md
@@ -1,0 +1,297 @@
+# WorkspaceItem data of submission-form sectionType
+[Back to the definition of the workspaceitems endpoint](workspaceitems.md)
+
+The section data represent the metadata collected for a specific [submissionform](submissionforms.md) it is a json object with the following structure
+
+```json
+{
+  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+  "dc.contributor.author" : [
+  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600}
+  ]
+}
+```
+
+The attribute name is the metadata key using the '.' dot separator (i.e. dc.title, dc.contributor.author, etc.) the value is an array, sorted by the metadatavalue.place column, containing
+* value: the textual value of the metadata
+* authority: the authority key if any associated
+* confidence: the level of confidence for the authority if any, -1 otherwise
+* language: the iso code associated with the textual value if any
+
+## Patch operations
+The PATCH method expects a JSON body according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902)
+
+### Add
+To add a new value to an **existent metadata** the client must send a JSON Patch ADD operation as follow
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/<:metadata>/-", "value": {value: "...", authority: "...", confidence: 600, language: ".."}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+it is also possible to insert the new metadata in a specific position
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/<:metadata>/<:idx-zero-based>", "value": {value: "...", authority: "...", confidence: 600, language: ".."}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+for example, starting with the following document  
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+		{
+		  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+		  "dc.contributor.author" : [
+		  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600}
+		  ]
+		},
+		...
+	},
+	...
+}	
+```
+
+the following request 
+`curl --data '{[ { "op": "add", "path": "/sections/traditional-page1/dc.contributor.author/-", "value": {value: "Another, Author"}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+will result in
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+		{
+		  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+		  "dc.contributor.author" : [
+		  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600},
+		  	 		{value: "Another, Author", confidence: -1}
+		  ]
+		},
+		...
+	},
+	...
+}	
+```
+
+and an additional call as follow
+`curl --data '{[ { "op": "add", "path": "/sections/traditional-page1/dc.contributor.author/1", "value": {value: "Insert, Test", authority: "rp00002", confidence: 600}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+will get the final document
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+		{
+		  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+		  "dc.contributor.author" : [
+		  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600},
+		  	 		{value: "Insert, Test", authority: "rp00002", confidence: 600},
+		  	 		{value: "Another, Author", confidence: -1}
+		  ]
+		},
+		...
+	},
+	...
+}	
+```
+
+Please note that according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) to initialize a new metadata in the section the add operation must receive an array of values and it is not possible to add a single value to the not yet initialized "/sections/<:name-of-the-form>/<:metadata>/-" path.
+For example the following call will add the first keyword to our previous example
+
+`curl --data '{[ { "op": "add", "path": "/sections/traditional-page1/dc.subject", "value": [{value: "keyword1"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+will get the final document
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+		{
+		  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+		  "dc.contributor.author" : [
+		  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600},
+		  	 		{value: "Insert, Test", authority: "rp00002", confidence: 600},
+		  	 		{value: "Another, Author", confidence: -1}
+		  ],
+		  "dc.subject" : [{value: "keyword1"}]
+		},
+		...
+	},
+	...
+}	
+```
+
+it is also possible to initialize or **replace** the whole metadata values sending multiple objectvalue in the call
+`curl --data '{[ { "op": "add", "path": "/sections/traditional-page1/dc.subject", "value": [{value: "keyword1"},{value: "keyword2"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+		{
+		  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+		  "dc.contributor.author" : [
+		  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600},
+		  	 		{value: "Insert, Test", authority: "rp00002", confidence: 600},
+		  	 		{value: "Another, Author", confidence: -1}
+		  ],
+		  "dc.subject" : [{value: "keyword1"}, {value: "keyword2"}]
+		},
+		...
+	},
+	...
+}	
+```
+
+This use of the add operation to replace the list of values of a metadata could be counter intuitive but it is done according to the [RFC section 4.1](https://tools.ietf.org/html/rfc6902#section-4.1)
+> If the target location specifies an object member that does exist, that member's value is replaced.
+
+the specification explicitly say that trying to send the request against the *- array position index* will create a sub-array element, see the [specification Appendix A.16](https://tools.ietf.org/html/rfc6902#page-18)   
+
+### Remove
+It is possible to remove a specific metadatavalue
+`curl --data '{[ { "op": "remove", "path": "/sections/traditional-page1/dc.subject/0"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+trasforming
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+		{
+		  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+		  "dc.contributor.author" : [
+		  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600},
+		  	 		{value: "Insert, Test", authority: "rp00002", confidence: 600},
+		  	 		{value: "Another, Author", confidence: -1}
+		  ],
+		  "dc.subject" : [{value: "keyword1"}, {value: "keyword2"}]
+		},
+		...
+	},
+	...
+}	
+```
+in
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+		{
+		  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+		  "dc.contributor.author" : [
+		  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600},
+		  	 		{value: "Insert, Test", authority: "rp00002", confidence: 600},
+		  	 		{value: "Another, Author", confidence: -1}
+		  ],
+		  "dc.subject" : [{value: "keyword2"}]
+		},
+		...
+	},
+	...
+}	
+```
+or removing all the metadata values for a specific metadata key
+`curl --data '{[ { "op": "remove", "path": "/sections/traditional-page1/dc.contributor.author"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+		{
+		  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+		  "dc.subject" : [{value: "keyword2"}]
+		},
+		...
+	},
+	...
+}	
+```
+ 
+### Replace
+The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation to set not yet initialized information must return an error. See [general errors on PATCH requests](patch.md)
+
+To change the title of the previous example
+`curl --data '{[ { "op": "replace", "path": "/sections/traditional-page1/dc.title/0", "value": {value: "Modified title", language:"en"}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+		{
+		  "dc.title" : [{value: "Modified title", language: "en"}],
+		  "dc.subject" : [{value: "keyword2"}]
+		},
+		...
+	},
+	...
+}	
+```
+
+It is also possible to change only the language of the existent title 
+`curl --data '{[ { "op": "replace", "path": "/sections/traditional-page1/dc.title/0/language", "value": "it"}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+		{
+		  "dc.title" : [{value: "Modified title", language: "it"}],
+		  "dc.subject" : [{value: "keyword2"}]
+		},
+		...
+	},
+	...
+}	
+```
+
+### Move
+It is possible to rearrange the metadata values using the move operation. For instance to put the 3rd author of the following workspaceitem 
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+		{
+		  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+		  "dc.contributor.author" : [
+		  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600},
+		  	 		{value: "Insert, Test", authority: "rp00002", confidence: 600},
+		  	 		{value: "Another, Author", confidence: -1}
+		  ],
+		  "dc.subject" : [{value: "keyword2"}]
+		},
+		...
+	},
+	...
+}	
+```
+
+as first author you need to run
+`curl --data '{[ { "op": "move", "from": "/sections/traditional-page1/dc.contributor/2", "path": "/sections/traditional-page1/dc.contributor/0"}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+
+### Test & copy
+No plan to implement the test and copy operation at the current stage

--- a/workspaceitem-data-upload.md
+++ b/workspaceitem-data-upload.md
@@ -1,0 +1,205 @@
+# WorkspaceItem data of upload sectionType
+[Back to the definition of the workspaceitems endpoint](workspaceitems.md)
+
+The section data represent the data about the user uploaded files
+
+```json
+{
+	"files": [ 
+  	 	{
+  	 		metadata: {
+  	 			"dc.title" : [{value: "sample_file.pdf"}],
+  	 			"dc.description" : [{value: "Description of the sample file"}]
+  	 		},
+  	 		"sizeBytes": 8528,
+			"checkSum": {
+			    "checkSumAlgorithm": "MD5",
+			    "value": "9d8f0f9e369cf12159d47c146c499cf4"
+			},
+  	 		"url": "http://dspace7.4science.it/api/core/bitstreams/00001abf-b2e0-477a-99de-104db7cb6469/content",
+  	 		"accessConditions": [
+  	 			{
+  	 				"id": 123,
+	  	 			"name": "openaccess",
+	  	 			"groupUUID": "uuid-of-the-anonymous-group"
+  	 			},
+  	 			{
+  	 				"id": 126,
+	  	 			"name": "administrator",
+	  	 			"groupUUID": "uuid-of-the-administrator-group"
+  	 			},
+  	 			{
+  	 				"id": 127,
+	  	 			"name": "embargo",
+	  	 			"groupUUID": "1faf7c51-2a14-4826-b0b1-f1c1d2d82dd7",
+	  	 			"startDate": "2018-06-24T00:40:54.970+0000"
+  	 			},
+  	 			{
+  	 				"id": 128,
+	  	 			"name": "lease",
+	  	 			"groupUUID": "38ecd5ae-af12-4144-a276-81532e1679f8",
+	  	 			"endDate": "2017-12-24T00:40:54.970+0000"
+  	 			}
+  	 		]
+ 		}
+ 	]
+}
+```
+the files attribute contains the list of user uploaded file in the section. For each file the following attributes exist
+* metadata: the map of the metadata assigned to the specific file with [the same structure](workspaceitem-data-metadata.md) used in the submission-form sectionType for the item metadata
+* sizeBytes (**READ-ONLY**): the size of the received file as calculated on the server at the receiving time 
+* checkSum (**READ-ONLY**): the checksum details (algorithm and value) of the received file as calculated on the server at the receiving time
+* url (**READ-ONLY**): from where the file can be downloaded
+* accessConditions: an array of all the policies that has been applied by the user to the file. 
+
+## Patch operations
+The PATCH method expects a JSON body according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902)
+
+Each successful Patch operation will return a HTTP 200 CODE with the new workspaceitem as body. See also the [General rules for the Patch operation](patch.md) for more details.
+
+### Add
+The add operation is used to add new metadata or access condition to already uploaded files. To upload a completely new file a [POST Multipart request must be issued against the workspaceitems endpoint, see here](workspaceitems.md).
+
+#### Metadata
+To add a value to an **existent metadata** the client must send a JSON Patch ADD operation as follow
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/files/<:file-idx>/metadata/<:metadata>/-", "value": {value: "...", authority: "...", confidence: 600, language: ".."}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+it is also possible to insert the new metadata in a specific position
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/files/<:file-idx>/metadata/<:metadata>/<:idx-zero-based>", "value": {value: "...", authority: "...", confidence: 600, language: ".."}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+To **initialize or replace completely** the values of a specific metadata
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/files/<:file-idx>/metadata/<:metadata>", "value": [{value: "...", authority: "...", confidence: 600, language: ".."}]}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+ 
+for instance the call
+`curl --data '{[ { "op": "add", "path": "/sections/uploads/files/0/metadata/dc.title", "value": [{value: "MyFile.pdf"}]}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+will set the title of the first uploaded file to MyFile.pdf returning the following json document
+```json
+{
+	id: 1,
+	type: "workspaceitem",
+	sections:
+	{
+		"traditional-page1":
+		{
+		  "dc.title" : [{value: "Sample Submission Item", language: "en"}],
+		  "dc.contributor.author" : [
+		  	 		{value: "Bollini, Andrea", authority: "rp00001", confidence: 600}
+		  ]
+		},
+		"uploads":
+		{	
+			"files": [ 
+	  	 	{
+	  	 		metadata: {
+	  	 			"dc.title" : [{value: "MyFile.pdf"}],
+	  	 			"dc.description" : [{value: "Description of the sample file"}]
+	  	 		},
+	  	 		"sizeBytes": 8528,
+				"checkSum": {
+				    "checkSumAlgorithm": "MD5",
+				    "value": "9d8f0f9e369cf12159d47c146c499cf4"
+				},
+	  	 		"url": "http://dspace7.4science.it/api/core/bitstreams/00001abf-b2e0-477a-99de-104db7cb6469/content",
+	  	 		"accessConditions": [
+	  	 			{
+	  	 				"id": 123,
+		  	 			"name": "openaccess",
+		  	 			"groupUUID": "uuid-of-the-anonymous-group"
+	  	 			},
+	  	 			{
+	  	 				"id": 126,
+		  	 			"name": "administrator",
+		  	 			"groupUUID": "uuid-of-the-administrator-group"
+	  	 			},
+	  	 			{
+	  	 				"id": 127,
+		  	 			"name": "embargo",
+		  	 			"groupUUID": "1faf7c51-2a14-4826-b0b1-f1c1d2d82dd7",
+		  	 			"startDate": "2018-06-24T00:40:54.970+0000"
+	  	 			},
+	  	 			{
+	  	 				"id": 128,
+		  	 			"name": "lease",
+		  	 			"groupUUID": "38ecd5ae-af12-4144-a276-81532e1679f8",
+		  	 			"endDate": "2017-12-24T00:40:54.970+0000"
+	  	 			}
+	  	 		]
+	 		}
+ 		]
+		}
+	}
+}
+```
+
+you can find more example to manipulate metadata in the documentation about [the submission-form sectionType](workspaceitem-data-metadata.md) you will only need to use the *path* to the file'metadata as specified above, i.e. adding /files/<:idx-file>/metadata/
+
+#### Access Condition
+To add an access condition the client must send a JSON Patch ADD operation as follow
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/files/<:file-idx>/accessConditions/-", "value": {name: "...", groupUUID: "...", endDate: ".."}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+to **replace completely** the access conditions applied to a specific file
+
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/files/<:file-idx>/accessCondition", "value": [{name: "...", groupUUID: "...", endDate: ".."}]}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>
+
+The exact attributes that the access condition to add must have depend on the name attribute that will identify the access condition configuration as exposed by the [submissionupload configuration endpoint](submissionuploads.md).
+For instance the following request is valid
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/files/<:file-idx>/accessConditions/-", "value": {name: "openaccess"}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+instead the request
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/files/<:file-idx>/accessConditions/-", "value": {name: "embargo"}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+will be rejected because a startDate attribute is also expected when an embargo is applied (according to the example configuration listed in this doc for the [submissionupload configuration endpoint](submissionuploads.md). The right request will be
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/files/<:file-idx>/accessConditions/-", "value": {name: "embargo", startDate: "2018-12-31"}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+Please note that doesn't make sense to add an access condition in a specific index and, to simplify the client implementation it was assumed that the accessCondition array is never *null* but eventually an empty array so that you call always append new AccessCondition to the path "/sections/<:name-of-the-form>/files/<:file-idx>/accessCondition/-".
+
+### Remove
+It is possible to remove an uploaded file specifying its index in the path of a remove operation 
+`curl --data '{[ { "op": "remove", "path": "/sections/uploads/files/<:idx-file>"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+#### Metadata
+Similarly to what has been described for the add operation you can look to the documentation about [the submission-form sectionType](workspaceitem-data-metadata.md) for example about how to remove a metadata or a single metadata value for the file. You will only need to use the *path* to the file'metadata as specified above, i.e. adding /files/<:idx-file>/metadata/
+
+#### Access Condition
+To remove a previous applied access condition it is sufficient to invoke a remove operation on the accessCondition position path, i.e.
+`curl --data '{[ { "op": "remove", "path": "/sections/uploads/files/<:idx-file>/accessConditions/<:access-idx>"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+the following request will reset the access condition of the specified file to the empty array
+`curl --data '{[ { "op": "remove", "path": "/sections/uploads/files/<:idx-file>/accessConditions"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+
+### Replace
+The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation without a previous value must return an error. See [general errors on PATCH requests](patch.md)
+
+#### Metadata
+Similarly to what has been described for the add operation you can look to the documentation about [the submission-form sectionType](workspaceitem-data-metadata.md) for example about how to replace a metadata or a single metadata value for the file. You will only need to use the *path* to the file'metadata as specified above, i.e. adding /files/<:idx-file>/metadata/
+
+#### Access Condition
+You can replace an existent access condition with a new one or update some settings of an existent access condition using the replace operation. The new settings must be valid for the selected access condition (name) according to the [submissionupload configuration endpoint](submissionuploads.md).
+
+To replace an access condition with a new one
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/files/<:file-idx>/accessConditions/0", "value": {name: "embargo", startDate: "2018-12-31"}}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+to update the embargo start date
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/files/<:file-idx>/accessConditions/0/startDate", "value": "2019-12-31"}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+to transform an existent *openaccess* access condition to an *administrator* access condition
+`curl --data '{[ { "op": "add", "path": "/sections/<:name-of-the-form>/files/<:file-idx>/accessConditions/0/name", "value": "administrator"}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+please note that the above works only because of openaccess and administrator have the same settings needs (no need of addition information). Indeed, the backend is expected to remove the existent policy and create a new policy. If the settings of the previous and new access condition differs the request must fail with a 422 error code
+
+### Move
+The move operation is allowed to the files index path to change the order of the uploaded file. 
+
+The following request will move the 3rd uploaded file in the first position
+`curl --data '{[ { "op": "add", "from":"/sections/<:name-of-the-form>/files/2", "path": "/sections/<:name-of-the-form>/files/0}]}' -X PATCH ${dspace7-url}/api/submission/workspaceitems/<:id>`
+
+#### Metadata
+Similarly to what has been described for the add operation you can look to the documentation about [the submission-form sectionType](workspaceitem-data-metadata.md) for example about how to move a metadata value for the file in the case the metadata is repeatable. You will only need to use the *path* to the file'metadata as specified above, i.e. adding /files/<:idx-file>/metadata/
+
+### Test & copy
+No plan to implement the test and copy operations at the current stage

--- a/workspaceitems.md
+++ b/workspaceitems.md
@@ -120,3 +120,7 @@ In addition, it allows in future to change the 1:1 association between collectio
 **/api/submission/workspaceitems/search/findBySubmitter?uuid=<:submitter-uuid>**
 
 It returns the workspaceitem created by the specified submitter
+
+## Multipart POST Method
+Multipart POST request will typically result in the creation of a new file in the section identified by the name of the variable used for the upload (uploads is the default name of the user uploaded content). The process will be managed by the implementation bind with the identified section.
+If succeed a 201 code will be returned and the new state of the workspaceitem serialized in the body.   

--- a/workspaceitems.md
+++ b/workspaceitems.md
@@ -82,7 +82,7 @@ Provide detailed information about a specific workspaceitem. The JSON response d
 }
 ```
 
-The actual data of the inprogress submission are arranged in *sections* map following the sections configured in the submissionDefinition. This map is *open for extension*, each type of section will expose a different JSON structure  
+The actual data of the inprogress submission are arranged in *sections* map following the sections configured in the submissionDefinition. This map is *open for extension*, each type of section will expose a different JSON structure. See the [out-of-box submission section types](submissionsection-types.md) page for details.
 
 Exposed links:
 * collection: the collection where the inprogress submission will be created

--- a/workspaceitems.md
+++ b/workspaceitems.md
@@ -48,18 +48,24 @@ Provide detailed information about a specific workspaceitem. The JSON response d
   	 		"url": "http://dspace7.4science.it/api/core/bitstreams/00001abf-b2e0-477a-99de-104db7cb6469/content",
   	 		"accessConditions": [
   	 			{
-	  	 			"type": "openaccess"
+  	 				"id": 123,
+	  	 			"name": "openaccess",
+	  	 			"groupUUID": "uuid-of-the-anonymous-group"
   	 			},
   	 			{
-	  	 			"type": "administrator"
+  	 				"id": 126,
+	  	 			"name": "administrator",
+	  	 			"groupUUID": "uuid-of-the-administrator-group"
   	 			},
   	 			{
-	  	 			"type": "embargo",
+  	 				"id": 127,
+	  	 			"name": "embargo",
 	  	 			"groupUUID": "1faf7c51-2a14-4826-b0b1-f1c1d2d82dd7",
-	  	 			"endDate": "2018-06-24T00:40:54.970+0000"
+	  	 			"startDate": "2018-06-24T00:40:54.970+0000"
   	 			},
   	 			{
-	  	 			"type": "lease",
+  	 				"id": 128,
+	  	 			"name": "lease",
 	  	 			"groupUUID": "38ecd5ae-af12-4144-a276-81532e1679f8",
 	  	 			"endDate": "2017-12-24T00:40:54.970+0000"
   	 			}
@@ -69,7 +75,7 @@ Provide detailed information about a specific workspaceitem. The JSON response d
   	},
   	 "cclicense": {
   	 	"image-url": "https://i.creativecommons.org/l/by/4.0/88x31.png",
-  	 	"text-url": "https://creativecommons.org/licenses/by/4.0/"
+  	 	"license-uri": "https://creativecommons.org/licenses/by/4.0/"
   	 }
   },
   "type": "workspaceitem"


### PR DESCRIPTION
This PR adds lot of documentation to our existent REST contract with a focus on the PATCH method for the workspaceitem but also covering some existent endpoint that were not previously documented or extending existent documentation.
IMHO the best way to review is to navigate the remote branch as you will see the rendered markdown  https://github.com/4Science/Rest7Contract/tree/DS-3759

Please note that this is what we plan to implement in https://github.com/DSpace/DSpace/pull/1889 we are close to have it properly implemented but in the current implementation we have take some shortcut to be able to demonstrate it also if it is not yet perfect