### PR TITLE
DS-3763: Scripts and processes endpoint

### DIFF
--- a/processes-endpoint.md
+++ b/processes-endpoint.md
@@ -131,7 +131,7 @@ This endpoint will return details on the requested process.
 }
 ```
 
-The possible `status` values are `RUNNING`, `STOPPED` and `FAILED`.
+The possible `status` values are `RUNNING`, `COMPLETED` and `FAILED`.
 
 ## Execution Console Output
 **GET /api/system/processes/<:process-id>/output**
@@ -212,4 +212,4 @@ Delayed scripts using a  `startTime` can be supported in a future version.
 }
 ```
 
-The possible `status` values are `RUNNING`, `STOPPED` and `FAILED`.
+The possible `status` values are `RUNNING`, `COMPLETED` and `FAILED`.

--- a/processes-endpoint.md
+++ b/processes-endpoint.md
@@ -1,0 +1,101 @@
+# Admin Processes Endpoints
+[Back to the list of all defined endpoints](endpoints.md)
+
+This endpoint allows adminstrators to list and manipulate script processes created by the [Scripts endpoint](scripts-endpoint.md).
+
+## Execution List
+** GET /api/admin/processes**
+
+This endpoint will return a list of all created processes. The JSON response document is as follow:
+
+```
+{
+  "page": {
+      	"size": 5,
+      	"totalElements": 14,
+      	"totalPages": 3,
+      	"number": 0
+  },
+  "sort" : {
+    "by" : "name",
+    "order" : "asc"
+  },
+  "_embedded" : {
+    "processes" [
+      {
+        "processId" : "000003f1-a850-49de-af03-997272d834c9",
+        "scriptName" : "import",
+        "startTime" : "2017-11-22T10:29:11Z",
+        "status" : "RUNNING"
+        "_links" : {
+          "self" : {
+            "href" : "/api/admin/processes/000003f1-a850-49de-af03-997272d834c9"
+          }
+        }
+      },
+      {
+        "processId" : "d3007ea8-1cc0-481d-914a-06720a200edf",
+        "scriptName" : "metadata-export",
+        "startTime" : "2017-11-20T10:29:11Z",
+        "status" : "FAILED"
+        "_links" : {
+          "self" : {
+            "href" : "/api/admin/processes/000003f1-a850-49de-af03-997272d834c9"
+          }
+        }
+      },
+      ...
+    ]
+  }
+```
+## Execution Details
+** GET /api/admin/processes/<:process-id>**
+
+This endpoint will return details on the requested process.
+
+```
+{
+  "processId" : "000003f1-a850-49de-af03-997272d834c9",
+  "scriptName" : "import",
+  "startTime" : "2017-11-22T10:29:11Z",
+  "status" : "RUNNING"
+  "_links" : {
+    "self" : {
+      "href" : "/api/admin/processes/000003f1-a850-49de-af03-997272d834c9"
+    }
+  }
+}
+```
+
+The possible `status` values are `RUNNING`, `STOPPED`, `FAILED` and `SCHEDULED`.
+
+## Execution Console Output
+** GET /api/admin/processes/<:process-id>/output**
+
+This endpoint will return the console output of the script, if any, in plain text.
+
+```
+Adding items from directory: /Users/tom/Development/dspaces/dspace7/imports/saf.zip
+Generating mapfile: temp
+Adding item from directory item_1
+	Loading dublin core from /Users/tom/Development/dspaces/dspace7/imports/saf.zip/item_1/dublin_core.xml
+	Schema: dc Element: title Qualifier:  Value: Bunny Video
+	Processing contents file: /Users/tom/Development/dspaces/dspace7/imports/saf.zip/item_1/contents
+	Bitstream: mp4test.mp4
+Processing handle file: handle
+It appears there is no handle file -- generating one
+0 item_1
+```
+
+## Execution File Output
+** GET /api/admin/processes/<:process-id>/file**
+
+This endpoint will let an administrator download an output file created by a process. If the file is found, it will be presented as a download. This endpoint will support "Range" HTTP headers so that downloads can be paused and resumed.
+
+Parameters:
+* `name`: The name of the output file to retrieve
+
+## Execution Deletion
+** DELETE /api/admin/processes/<:process-id>**
+
+If the process is still in a `RUNNING` or `SCHEDULED` status, a best-effort attempt will be made to stop the process. Then the process information will be removed.

--- a/processes-endpoint.md
+++ b/processes-endpoint.md
@@ -217,3 +217,7 @@ Delayed scripts using a  `startTime` can be supported in a future version.
 ```
 
 The possible `status` values are `SCHEDULED`, `RUNNING`, `COMPLETED` and `FAILED`.
+
+Status codes:
+* 202 Accepted - if the task is accepted for processing
+* 404 Not found - if the script doesn't exist

--- a/processes-endpoint.md
+++ b/processes-endpoint.md
@@ -1,14 +1,14 @@
 # Admin Processes Endpoints
 [Back to the list of all defined endpoints](endpoints.md)
 
-This endpoint allows adminstrators to list and manipulate script processes created by the [Scripts endpoint](scripts-endpoint.md).
+This endpoint allows users to list and manipulate script processes created by the [Scripts endpoint](scripts-endpoint.md).
 
 ## Execution List
-**GET /api/admin/processes**
+**GET /api/system/processes**
 
 This endpoint will return a list of all created processes. The JSON response document is as follows:
 
-```
+```json
 {
   "page": {
       	"size": 5,
@@ -17,91 +17,199 @@ This endpoint will return a list of all created processes. The JSON response doc
       	"number": 0
   },
   "sort" : {
-    "by" : "name",
+    "by" : "script",
     "order" : "asc"
   },
   "_embedded" : {
-    "processes" [
+    "processes" : [
       {
         "processId" : "000003f1-a850-49de-af03-997272d834c9",
-        "scriptName" : "import",
+        "userId" : "aa0263e2-b90a-4528-89fa-116ea4859de1",
         "startTime" : "2017-11-22T10:29:11Z",
-        "status" : "RUNNING"
+        "status" : "RUNNING",
+        "parameters" : [
+          {
+            "name" : "c",
+            "value" : "954e5cfa-6990-4c85-ae42-f30d8c7888e2"
+          },
+          {
+            "name" : "n",
+            "value" : "true"
+          }
+        ],
         "_links" : {
           "self" : {
-            "href" : "/api/admin/processes/000003f1-a850-49de-af03-997272d834c9"
+            "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9"
+          },
+          "script" : {
+            "href" : "/api/system/scripts/import"
+          },
+          "output" : {
+            "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/output"
+          },
+          "files" : {
+            "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/files"
           }
         }
       },
       {
         "processId" : "d3007ea8-1cc0-481d-914a-06720a200edf",
-        "scriptName" : "metadata-export",
+        "userId" : "c7d85e7f-63e5-4bc0-96cb-5d80be48d62e",
         "startTime" : "2017-11-20T10:29:11Z",
-        "status" : "FAILED"
+        "status" : "FAILED",
+        "parameters" : [
+          {
+            "name" : "i",
+            "value" : "c70893a6-ac55-48c7-9447-61e026b62929"
+          }
+        ],
         "_links" : {
           "self" : {
-            "href" : "/api/admin/processes/000003f1-a850-49de-af03-997272d834c9"
+            "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9"
+          },
+          "script" : {
+            "href" : "/api/system/scripts/metadata-export"
+          },
+          "output" : {
+            "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/output"
+          },
+          "files" : {
+            "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/files"
           }
         }
-      },
-      ...
+      }
     ]
   }
+}
 ```
+
+Optional parameters to query the processes:
+* `script`: The name of the script (e.g. import)
+* `userId`: The UUID of the person who created the process (only admins can retrieve processes they didn't start)
+* `status`: The status of the script
+* `parameter.xyz`: Which parameters have been used, and their value
+
+Sort options should support:
+* `script`
+* `startTime`
+
 ## Execution Details
-**GET /api/admin/processes/<:process-id>**
+**GET /api/system/processes/<:process-id>**
 
 This endpoint will return details on the requested process.
 
-```
+```json
 {
   "processId" : "000003f1-a850-49de-af03-997272d834c9",
-  "scriptName" : "import",
+  "userId" : "aa0263e2-b90a-4528-89fa-116ea4859de1",
   "startTime" : "2017-11-22T10:29:11Z",
-  "status" : "RUNNING"
+  "status" : "RUNNING",
+  "parameters" : [
+    {
+    "name" : "c",
+    "value" : "954e5cfa-6990-4c85-ae42-f30d8c7888e2"
+    },
+    {
+    "name" : "n",
+    "value" : "true"
+    }
+  ],
   "_links" : {
     "self" : {
-      "href" : "/api/admin/processes/000003f1-a850-49de-af03-997272d834c9"
+      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9"
+    },
+    "script" : {
+      "href" : "/api/system/scripts/import"
+    },
+    "output" : {
+      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/output"
+    },
+    "files" : {
+      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/files"
     }
   }
 }
 ```
 
-The possible `status` values are `RUNNING`, `STOPPED`, `FAILED` and `SCHEDULED`.
+The possible `status` values are `RUNNING`, `STOPPED` and `FAILED`.
 
 ## Execution Console Output
-**GET /api/admin/processes/<:process-id>/output**
+**GET /api/system/processes/<:process-id>/output**
 
-This endpoint will return the console output of the script, if any, in a JSON format annotated with timestamps.
+This endpoint will return the console output of the script. To keep the scope of this work limited, it will print the full console output without datestamps.
+In a future version, a solution supporting a live-feed can also be included.
 
-The endpoint supports the following optional parameters:
-* `fromTime`: A timestamp starting starting from which the console output entries have to be returned
-* `toTime`: A timestamp up until which the console output entries have to be returned
+## Execution File Output List
+**GET /api/system/processes/<:process-id>/files**
 
-```
-[
-{ "time" : 2017-11-21T11:32:52Z", "line" : "Adding items from directory: /Users/tom/Development/dspaces/dspace7/imports/saf.zip" },
-{ "time" : 2017-11-21T11:32:54Z", "line" : "Generating mapfile: temp" },
-{ "time" : 2017-11-21T11:32:56Z", "line" : "Adding item from directory item_1" },
-{ "time" : 2017-11-21T11:32:58Z", "line" : "	Loading dublin core from /Users/tom/Development/dspaces/dspace7/imports/saf.zip/item_1/dublin_core.xml" },
-{ "time" : 2017-11-21T11:33:00Z", "line" : "	Schema: dc Element: title Qualifier:  Value: Bunny Video" },
-{ "time" : 2017-11-21T11:33:02Z", "line" : "	Processing contents file: /Users/tom/Development/dspaces/dspace7/imports/saf.zip/item_1/contents" },
-{ "time" : 2017-11-21T11:33:04Z", "line" : "	Bitstream: mp4test.mp4" },
-{ "time" : 2017-11-21T11:33:06Z", "line" : "Processing handle file: handle" },
-{ "time" : 2017-11-21T11:33:08Z", "line" : "It appears there is no handle file -- generating one" },
-{ "time" : 2017-11-21T11:33:10Z", "line" : "0 item_1" }
-]
+This endpoint will let an administrator download an output file created by a process. If the file is found, it will be presented as a download. This endpoint will support "Range" HTTP headers so that downloads can be paused and resumed.
+
+```json
+{
+  "processId" : "000003f1-a850-49de-af03-997272d834c9",
+  "_links" : {
+    "self" : {
+      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/files"
+    },
+    "mapfile" : {
+      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/files/mapfile"
+    },
+    "zipfile" : {
+      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/files/zipfile"
+    }
+  }
+}
 ```
 
 ## Execution File Output
-**GET /api/admin/processes/<:process-id>/file**
+**GET /api/system/processes/<:process-id>/files/<:file-name>**
 
 This endpoint will let an administrator download an output file created by a process. If the file is found, it will be presented as a download. This endpoint will support "Range" HTTP headers so that downloads can be paused and resumed.
 
 Required parameters:
-* `name`: The name of the output file to retrieve
+* `file-name`: The name of the output file to retrieve
 
 ## Execution Deletion
-**DELETE /api/admin/processes/<:process-id>**
+**DELETE /api/system/processes/<:process-id>**
 
-If the process is still in a `RUNNING` or `SCHEDULED` status, a best-effort attempt will be made to stop the process. Then the process information will be removed.
+The will delete the process and associated files and output.
+
+Support for stopping a process can be included in a future version
+
+### Script Invocation
+**POST /api/system/scripts/<:script-name>/processes**
+
+POST requests to this endpoint will start the corresponding script with the provided parameters. All parameter values should be provided in the body that has to use the `multipart/form-data` content type. Once the upload is complete and the script was started successfully, this endpoint will return details on the scripts execution
+
+Delayed scripts using a  `startTime` can be supported in a future version.
+
+```json
+{
+  "processId" : "000003f1-a850-49de-af03-997272d834c9",
+  "userId" : "aa0263e2-b90a-4528-89fa-116ea4859de1",
+  "status" : "RUNNING",
+  "parameters" : [
+    {
+    "name" : "c",
+    "value" : "954e5cfa-6990-4c85-ae42-f30d8c7888e2"
+    },
+    {
+    "name" : "n",
+    "value" : "true"
+    }
+  ],
+  "_links" : {
+    "self" : {
+      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9"
+    },
+    "script" : {
+      "href" : "/api/system/scripts/import"
+    },
+    "output" : {
+      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/output"
+    }
+  }
+}
+```
+
+The possible `status` values are `RUNNING`, `STOPPED` and `FAILED`.

--- a/processes-endpoint.md
+++ b/processes-endpoint.md
@@ -16,65 +16,65 @@ This endpoint will return a list of all created processes. The JSON response doc
       	"totalPages": 3,
       	"number": 0
   },
-  "sort" : {
-    "by" : "script",
-    "order" : "asc"
-  },
   "_embedded" : {
     "processes" : [
       {
-        "processId" : "000003f1-a850-49de-af03-997272d834c9",
+        "processId" : "1",
         "userId" : "aa0263e2-b90a-4528-89fa-116ea4859de1",
         "startTime" : "2017-11-22T10:29:11Z",
-        "status" : "RUNNING",
+        "endTime" : null,
+        "scriptName": "metadata-import",
+        "processStatus" : "RUNNING",
         "parameters" : [
           {
-            "name" : "c",
+            "name" : "-c",
             "value" : "954e5cfa-6990-4c85-ae42-f30d8c7888e2"
           },
           {
-            "name" : "n",
+            "name" : "-n",
             "value" : "true"
           }
         ],
         "_links" : {
           "self" : {
-            "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9"
+            "href" : "/api/system/processes/1"
           },
           "script" : {
             "href" : "/api/system/scripts/import"
           },
           "output" : {
-            "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/output"
+            "href" : "/api/system/processes/1/output"
           },
           "files" : {
-            "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/files"
+            "href" : "/api/system/processes/1/files"
           }
         }
       },
       {
-        "processId" : "d3007ea8-1cc0-481d-914a-06720a200edf",
+        "processId" : "2",
         "userId" : "c7d85e7f-63e5-4bc0-96cb-5d80be48d62e",
         "startTime" : "2017-11-20T10:29:11Z",
-        "status" : "FAILED",
+        "endTime" : "2017-11-20T10:30:11Z",
+        "scriptName": "metadata-import",
+        "processStatus" : "FAILED",
         "parameters" : [
           {
-            "name" : "i",
+            "name" : "-i",
             "value" : "c70893a6-ac55-48c7-9447-61e026b62929"
           }
         ],
         "_links" : {
           "self" : {
-            "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9"
+            "href" : "/api/system/processes/2"
           },
           "script" : {
             "href" : "/api/system/scripts/metadata-export"
           },
           "output" : {
-            "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/output"
+            "href" : "/api/system/processes/2/output"
           },
           "files" : {
-            "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/files"
+            "href" : "/api/system/processes/2/files"
           }
         }
       }
@@ -89,10 +89,6 @@ Optional parameters to query the processes:
 * `status`: The status of the script
 * `parameter.xyz`: Which parameters have been used, and their value
 
-Sort options should support:
-* `script`
-* `startTime`
-
 ## Execution Details
 **GET /api/system/processes/<:process-id>**
 
@@ -100,32 +96,34 @@ This endpoint will return details on the requested process.
 
 ```json
 {
-  "processId" : "000003f1-a850-49de-af03-997272d834c9",
+  "processId" : "3",
   "userId" : "aa0263e2-b90a-4528-89fa-116ea4859de1",
   "startTime" : "2017-11-22T10:29:11Z",
-  "status" : "RUNNING",
+  "endTime" : null,              
+  "scriptName": "metadata-import",
+  "processStatus" : "RUNNING",
   "parameters" : [
     {
-    "name" : "c",
+    "name" : "-c",
     "value" : "954e5cfa-6990-4c85-ae42-f30d8c7888e2"
     },
     {
-    "name" : "n",
+    "name" : "-n",
     "value" : "true"
     }
   ],
   "_links" : {
     "self" : {
-      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9"
+      "href" : "/api/system/processes/3"
     },
     "script" : {
       "href" : "/api/system/scripts/import"
     },
     "output" : {
-      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/output"
+      "href" : "/api/system/processes/3/output"
     },
     "files" : {
-      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/files"
+      "href" : "/api/system/processes/3/files"
     }
   }
 }
@@ -146,16 +144,16 @@ This endpoint will let an administrator download an output file created by a pro
 
 ```json
 {
-  "processId" : "000003f1-a850-49de-af03-997272d834c9",
+  "processId" : "4",
   "_links" : {
     "self" : {
-      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/files"
+      "href" : "/api/system/processes/4/files"
     },
     "mapfile" : {
-      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/files/mapfile"
+      "href" : "/api/system/processes/4/files/mapfile"
     },
     "zipfile" : {
-      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/files/zipfile"
+      "href" : "/api/system/processes/4/files/zipfile"
     }
   }
 }
@@ -172,9 +170,15 @@ Required parameters:
 ## Execution Deletion
 **DELETE /api/system/processes/<:process-id>**
 
-The will delete the process and associated files and output.
+The will delete the process and associated files and output. Only processes with states of `SCHEDULED`, `COMPLETED` and `FAILED` can be deleted. 
 
-Support for stopping a process can be included in a future version
+Support for stopping a process can be included in a future version.
+
+Status codes:
+* 201 Created - if the operation succeed
+* 404 Not found - if the processes doesn't exist
+* 422 Unprocessable Entity - If the process is running
+
 
 ### Script Invocation
 **POST /api/system/scripts/<:script-name>/processes**
@@ -185,31 +189,31 @@ Delayed scripts using a  `startTime` can be supported in a future version.
 
 ```json
 {
-  "processId" : "000003f1-a850-49de-af03-997272d834c9",
+  "processId" : "5",
   "userId" : "aa0263e2-b90a-4528-89fa-116ea4859de1",
-  "status" : "RUNNING",
+  "processStatus" : "RUNNING",
   "parameters" : [
     {
-    "name" : "c",
+    "name" : "-c",
     "value" : "954e5cfa-6990-4c85-ae42-f30d8c7888e2"
     },
     {
-    "name" : "n",
+    "name" : "-n",
     "value" : "true"
     }
   ],
   "_links" : {
     "self" : {
-      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9"
+      "href" : "/api/system/processes/5"
     },
     "script" : {
       "href" : "/api/system/scripts/import"
     },
     "output" : {
-      "href" : "/api/system/processes/000003f1-a850-49de-af03-997272d834c9/output"
+      "href" : "/api/system/processes/5/output"
     }
   }
 }
 ```
 
-The possible `status` values are `RUNNING`, `COMPLETED` and `FAILED`.
+The possible `status` values are `SCHEDULED`, `RUNNING`, `COMPLETED` and `FAILED`.

--- a/processes-endpoint.md
+++ b/processes-endpoint.md
@@ -4,9 +4,9 @@
 This endpoint allows adminstrators to list and manipulate script processes created by the [Scripts endpoint](scripts-endpoint.md).
 
 ## Execution List
-** GET /api/admin/processes**
+**GET /api/admin/processes**
 
-This endpoint will return a list of all created processes. The JSON response document is as follow:
+This endpoint will return a list of all created processes. The JSON response document is as follows:
 
 ```
 {
@@ -49,7 +49,7 @@ This endpoint will return a list of all created processes. The JSON response doc
   }
 ```
 ## Execution Details
-** GET /api/admin/processes/<:process-id>**
+**GET /api/admin/processes/<:process-id>**
 
 This endpoint will return details on the requested process.
 
@@ -70,32 +70,38 @@ This endpoint will return details on the requested process.
 The possible `status` values are `RUNNING`, `STOPPED`, `FAILED` and `SCHEDULED`.
 
 ## Execution Console Output
-** GET /api/admin/processes/<:process-id>/output**
+**GET /api/admin/processes/<:process-id>/output**
 
-This endpoint will return the console output of the script, if any, in plain text.
+This endpoint will return the console output of the script, if any, in a JSON format annotated with timestamps.
+
+The endpoint supports the following optional parameters:
+* `fromTime`: A timestamp starting starting from which the console output entries have to be returned
+* `toTime`: A timestamp up until which the console output entries have to be returned
 
 ```
-Adding items from directory: /Users/tom/Development/dspaces/dspace7/imports/saf.zip
-Generating mapfile: temp
-Adding item from directory item_1
-	Loading dublin core from /Users/tom/Development/dspaces/dspace7/imports/saf.zip/item_1/dublin_core.xml
-	Schema: dc Element: title Qualifier:  Value: Bunny Video
-	Processing contents file: /Users/tom/Development/dspaces/dspace7/imports/saf.zip/item_1/contents
-	Bitstream: mp4test.mp4
-Processing handle file: handle
-It appears there is no handle file -- generating one
-0 item_1
+[
+{ "time" : 2017-11-21T11:32:52Z", "line" : "Adding items from directory: /Users/tom/Development/dspaces/dspace7/imports/saf.zip" },
+{ "time" : 2017-11-21T11:32:54Z", "line" : "Generating mapfile: temp" },
+{ "time" : 2017-11-21T11:32:56Z", "line" : "Adding item from directory item_1" },
+{ "time" : 2017-11-21T11:32:58Z", "line" : "	Loading dublin core from /Users/tom/Development/dspaces/dspace7/imports/saf.zip/item_1/dublin_core.xml" },
+{ "time" : 2017-11-21T11:33:00Z", "line" : "	Schema: dc Element: title Qualifier:  Value: Bunny Video" },
+{ "time" : 2017-11-21T11:33:02Z", "line" : "	Processing contents file: /Users/tom/Development/dspaces/dspace7/imports/saf.zip/item_1/contents" },
+{ "time" : 2017-11-21T11:33:04Z", "line" : "	Bitstream: mp4test.mp4" },
+{ "time" : 2017-11-21T11:33:06Z", "line" : "Processing handle file: handle" },
+{ "time" : 2017-11-21T11:33:08Z", "line" : "It appears there is no handle file -- generating one" },
+{ "time" : 2017-11-21T11:33:10Z", "line" : "0 item_1" }
+]
 ```
 
 ## Execution File Output
-** GET /api/admin/processes/<:process-id>/file**
+**GET /api/admin/processes/<:process-id>/file**
 
 This endpoint will let an administrator download an output file created by a process. If the file is found, it will be presented as a download. This endpoint will support "Range" HTTP headers so that downloads can be paused and resumed.
 
-Parameters:
+Required parameters:
 * `name`: The name of the output file to retrieve
 
 ## Execution Deletion
-** DELETE /api/admin/processes/<:process-id>**
+**DELETE /api/admin/processes/<:process-id>**
 
 If the process is still in a `RUNNING` or `SCHEDULED` status, a best-effort attempt will be made to stop the process. Then the process information will be removed.

--- a/processes-endpoint.md
+++ b/processes-endpoint.md
@@ -180,44 +180,6 @@ Status codes:
 * 422 Unprocessable Entity - If the process is running
 
 
-### Script Invocation
-**POST /api/system/scripts/<:script-name>/processes**
+## Script Invocation
 
-POST requests to this endpoint will start the corresponding script with the provided parameters. All parameter values should be provided in the body that has to use the `multipart/form-data` content type. Once the upload is complete and the script was started successfully, this endpoint will return details on the scripts execution
-
-Delayed scripts using a  `startTime` can be supported in a future version.
-
-```json
-{
-  "processId" : "5",
-  "userId" : "aa0263e2-b90a-4528-89fa-116ea4859de1",
-  "processStatus" : "RUNNING",
-  "parameters" : [
-    {
-    "name" : "-c",
-    "value" : "954e5cfa-6990-4c85-ae42-f30d8c7888e2"
-    },
-    {
-    "name" : "-n",
-    "value" : "true"
-    }
-  ],
-  "_links" : {
-    "self" : {
-      "href" : "/api/system/processes/5"
-    },
-    "script" : {
-      "href" : "/api/system/scripts/import"
-    },
-    "output" : {
-      "href" : "/api/system/processes/5/output"
-    }
-  }
-}
-```
-
-The possible `status` values are `SCHEDULED`, `RUNNING`, `COMPLETED` and `FAILED`.
-
-Status codes:
-* 202 Accepted - if the task is accepted for processing
-* 404 Not found - if the script doesn't exist
+See the [scripts endpoint](scripts-endpoint.md#script-invocation) for details on how to start a script

--- a/scripts-endpoint.md
+++ b/scripts-endpoint.md
@@ -145,3 +145,45 @@ Following parameter types are available:
 * `boolean`: true or false
 * `file`: For parameters with this type, the user has to provide a file. This would be a multipart POST request using the same filename
 * `output`: Parameters with this type define the name of the output file. This name can be used later to download the the output file (e.g. when running `export` or `metadata-export`).
+
+## Script Invocation
+**POST /api/system/scripts/<:script-name>/processes**
+
+POST requests to this endpoint will start the corresponding script with the provided parameters. All parameter values should be provided in the body that has to use the `multipart/form-data` content type. Once the upload is complete and the script was started successfully, this endpoint will return details on the scripts execution
+
+Delayed scripts using a  `startTime` can be supported in a future version.
+
+```json
+{
+  "processId" : "5",
+  "userId" : "aa0263e2-b90a-4528-89fa-116ea4859de1",
+  "processStatus" : "RUNNING",
+  "parameters" : [
+    {
+    "name" : "-c",
+    "value" : "954e5cfa-6990-4c85-ae42-f30d8c7888e2"
+    },
+    {
+    "name" : "-n",
+    "value" : "true"
+    }
+  ],
+  "_links" : {
+    "self" : {
+      "href" : "/api/system/processes/5"
+    },
+    "script" : {
+      "href" : "/api/system/scripts/import"
+    },
+    "output" : {
+      "href" : "/api/system/processes/5/output"
+    }
+  }
+}
+```
+
+The possible `status` values are `SCHEDULED`, `RUNNING`, `COMPLETED` and `FAILED`.
+
+Status codes:
+* 202 Accepted - if the task is accepted for processing
+* 404 Not found - if the script doesn't exist

--- a/scripts-endpoint.md
+++ b/scripts-endpoint.md
@@ -1,15 +1,15 @@
 # Admin Scripts Endpoints
 [Back to the list of all defined endpoints](endpoints.md)
 
-DSpace (6) has admin functionality to import and export items in CSV and ZIP format, to start a collection harvest run, to run or schedule curation tasks. Each of these functionalities also map on a DSpace CLI script. While we could implement each of these operations as a separate endpoint, this contract tries to describe a generic endpoint that allows administrators to explore, run or schedule DSpace CLI scripts from the REST API.
+DSpace has functionality to import and export items in CSV and ZIP format, to start a collection harvest run, to run or schedule curation tasks, …. Each of these functionalities also map on a DSpace CLI script. While we could implement each of these operations as a separate endpoint, this contract tries to describe a generic endpoint that allows administrators to explore, run or schedule DSpace CLI scripts from the REST API.
 
 ## Scripts Endpoint
-**GET /api/admin/scripts**
+**GET /api/system/scripts**
 
 This endpoint will list all (REST supported) scripts defined in `dspace/config/launcher.xml`. The script entries are embedded with a name, description and a self link. By "REST supported" we mean all scripts that have been updated to allow invocations from the REST API.
 
 The JSON response document is as follows
-```
+```json
 {
   "page": {
       	"size": 5,
@@ -22,116 +22,116 @@ The JSON response document is as follows
     "order" : "asc"
   },
   "_embedded" : {
-    "scripts" [
+    "scripts" : [
       {
         "name" : "import",
-        "description" : "Import items into DSpace"
+        "description" : "Import items into DSpace",
         "_links" : {
           "self" : {
-            "href" : "/api/admin/scripts/import"
+            "href" : "/api/system/scripts/import"
           }
         }
       },
       {
         "name" : "metadata-import",
-        "description" : "Import metadata after batch editing"
+        "description" : "Import metadata after batch editing",
         "_links" : {
           "self" : {
-            "href" : "/api/admin/scripts/metadata-import"
+            "href" : "/api/system/scripts/metadata-import"
           }
         }
-      },
-      ...
+      }
     ]
   }
+}
 ```
 
 ## Script Name Endpoint
 
 ### Script Details
-**GET /api/admin/scripts/<:script-name>**
+**GET /api/system/scripts/<:script-name>**
 
-This endpoint will return information on all the parameters that are required to invoke the script. This dependens on the parameters defined in the implementation of the script.
+This endpoint will return information on all the parameters that are required to invoke the script. This depends on the parameters defined in the implementation of the script.
 
 The JSON response document is as follows
-```
+```json
 {
    "name" : "import",
    "description" : "Import items into DSpace",
    "parameters" : [
     {
       "name" : "a",
-      "description" : "add items to DSpace"
+      "description" : "add items to DSpace",
       "type" : "boolean"
     },
     {
       "name" : "b",
-      "description" : "add items to DSpace via Biblio-Transformation-Engine (BTE)"
+      "description" : "add items to DSpace via Biblio-Transformation-Engine (BTE)",
       "type" : "boolean"
     },
     {
       "name" : "c",
-      "description" : "destination collection(s) database ID"
+      "description" : "destination collection(s) database ID",
       "type" : "id"
     },
     {
       "name" : "d",
-      "description" : "delete items listed in mapfile"
+      "description" : "delete items listed in mapfile",
       "type" : "file"
     },
     {
       "name" : "e",
-      "description" : "email of eperson doing importing"
+      "description" : "email of eperson doing importing",
       "type" : "string"
     },
     {
       "name" : "i",
-      "description" : "input type in case of BTE import"
+      "description" : "input type in case of BTE import",
       "type" : "string"
     },
     {
       "name" : "n",
-      "description" : "if sending submissions through the workflow, send notification emails"
+      "description" : "if sending submissions through the workflow, send notification emails",
       "type" : "boolean"
     },
     {
       "name" : "p",
-      "description" : "apply template"
+      "description" : "apply template",
       "type" : "string"
     },
     {
       "name" : "q",
-      "description" : "don't display metadata"
+      "description" : "don't display metadata",
       "type" : "boolean"
     },
     {
       "name" : "m",
-      "description" : "mapfile items in mapfile"
+      "description" : "mapfile items in mapfile",
       "type" : "file"
     },
     {
       "name" : "r",
-      "description" : "replace items in mapfile"
+      "description" : "replace items in mapfile",
       "type" : "boolean"
     },
     {
       "name" : "R",
-      "description" : "resume a failed import (add only)"
+      "description" : "resume a failed import (add only)",
       "type" : "boolean"
     },
     {
       "name" : "t",
-      "description" : "test run - do not actually import items"
+      "description" : "test run - do not actually import items",
       "type" : "boolean"
     },
     {
       "name" : "w",
-      "description" : "send submission through collection's workflow"
+      "description" : "send submission through collection's workflow",
       "type" : "boolean"
     },
     {
       "name" : "z",
-      "description" : "zip file containig the import"
+      "description" : "zip file containig the import",
       "type" : "file"
     }
    ]
@@ -142,28 +142,5 @@ Following parameter types are available:
 * `string`: A regular string value
 * `date`: A string that has a valid date pattern
 * `boolean`: true or false
-* `file`: For parameters with this type, the user has to provide a file
+* `file`: For parameters with this type, the user has to provide a file. This would be a multipart POST request using the same filename
 * `output`: Parameters with this type define the name of the output file. This name can be used later to download the the output file (e.g. when running `export` or `metadata-export`).
-
-### Script Invocation
-**POST /api/admin/scripts/<:script-name>**
-
-POST requests to this endpoint will start the corresponding script with the provided parameters. All parameter values should be provided in the body that has to use the `multipart/form-data` content type. Once the upload is complete and the script was started successfully, this endpoint will return details on the scripts execution
-
-The POST request body can contain the optional parameter `startTime`. When this parameter contains a valid timestamp, the script will start at that timestamp.
-
-```
-{
-  "processId" : "000003f1-a850-49de-af03-997272d834c9",
-  "scriptName" : "import",
-  "startTime" : "2017-11-22T10:29:11Z",
-  "status" : "RUNNING",
-  "_links" : {
-    "self" : {
-      "href" : "/api/admin/processes/000003f1-a850-49de-af03-997272d834c9"
-    }
-  }
-}
-```
-
-The possible `status` values are `RUNNING`, `STOPPED`, `FAILED` and `SCHEDULED`.

--- a/scripts-endpoint.md
+++ b/scripts-endpoint.md
@@ -1,0 +1,169 @@
+# Admin Scripts Endpoints
+[Back to the list of all defined endpoints](endpoints.md)
+
+DSpace (6) has admin functionality to import and export items in CSV and ZIP format, to start a collection harvest run, to run or schedule curation tasks. Each of these functionalities also map on a DSpace CLI script. While we could implement each of these operations as a separate endpoint, this contract tries to describe a generic endpoint that allows administrators to explore, run or schedule DSpace CLI scripts from the REST API.
+
+## Scripts Endpoint
+** GET /api/admin/scripts**
+
+This endpoint will list all (REST supported) scripts defined in `dspace/config/launcher.xml`. The script entries are embedded with a name, description and a self link. By "REST supported" we mean all scripts that have been updated to allow invocations from the REST API.
+
+The JSON response document is as follow
+```
+{
+  "page": {
+      	"size": 5,
+      	"totalElements": 14,
+      	"totalPages": 3,
+      	"number": 0
+  },
+  "sort" : {
+    "by" : "name",
+    "order" : "asc"
+  },
+  "_embedded" : {
+    "scripts" [
+      {
+        "name" : "import",
+        "description" : "Import items into DSpace"
+        "_links" : {
+          "self" : {
+            "href" : "/api/admin/scripts/import"
+          }
+        }
+      },
+      {
+        "name" : "metadata-import",
+        "description" : "Import metadata after batch editing"
+        "_links" : {
+          "self" : {
+            "href" : "/api/admin/scripts/metadata-import"
+          }
+        }
+      },
+      ...
+    ]
+  }
+```
+
+## Script Name Endpoint
+
+### Script Details
+** GET /api/admin/scripts/<:script-name>**
+
+This endpoint will return information on all the parameters that are required to invoke the script. This dependens on the parameters defined in the implementation of the script.
+
+The JSON response document is as follow
+```
+{
+   "name" : "import",
+   "description" : "Import items into DSpace",
+   "parameters" : [
+    {
+      "name" : "a",
+      "description" : "add items to DSpace"
+      "type" : "boolean"
+    },
+    {
+      "name" : "b",
+      "description" : "add items to DSpace via Biblio-Transformation-Engine (BTE)"
+      "type" : "boolean"
+    },
+    {
+      "name" : "c",
+      "description" : "destination collection(s) database ID"
+      "type" : "id"
+    },
+    {
+      "name" : "d",
+      "description" : "delete items listed in mapfile"
+      "type" : "file"
+    },
+    {
+      "name" : "e",
+      "description" : "email of eperson doing importing"
+      "type" : "string"
+    },
+    {
+      "name" : "i",
+      "description" : "input type in case of BTE import"
+      "type" : "string"
+    },
+    {
+      "name" : "n",
+      "description" : "if sending submissions through the workflow, send notification emails"
+      "type" : "boolean"
+    },
+    {
+      "name" : "p",
+      "description" : "apply template"
+      "type" : "string"
+    },
+    {
+      "name" : "q",
+      "description" : "don't display metadata"
+      "type" : "boolean"
+    },
+    {
+      "name" : "m",
+      "description" : "mapfile items in mapfile"
+      "type" : "file"
+    },
+    {
+      "name" : "r",
+      "description" : "replace items in mapfile"
+      "type" : "boolean"
+    },
+    {
+      "name" : "R",
+      "description" : "resume a failed import (add only)"
+      "type" : "boolean"
+    },
+    {
+      "name" : "t",
+      "description" : "test run - do not actually import items"
+      "type" : "boolean"
+    },
+    {
+      "name" : "w",
+      "description" : "send submission through collection's workflow"
+      "type" : "boolean"
+    },
+    {
+      "name" : "z",
+      "description" : "zip file containig the import"
+      "type" : "file"
+    }
+   ]
+}
+```
+
+Following parameter types are available:
+* `string`: A regular string value
+* `date`: A string that has a valid date pattern
+* `boolean`: true or false
+* `file`: For parameters with this type, the user has to provide a file
+* `output`: Parameters with this type define the name of the output file. This name can be used later to download the the output file (e.g. when running `export` or `metadata-export`).
+
+### Script Invocation
+** POST /api/admin/scripts/<:script-name>**
+
+POST requests to this endpoint will start the corresponding script with the provided parameters. All parameter values should be provided in the body that has to use the `multipart/form-data` content type. Once the upload is complete and the script was started successfully, this endpoint will return details on the scripts execution
+
+The POST request body can contain the optional parameter `startTime`. When this parameter contains a valid timestamp, the script will start at that timestamp.
+
+```
+{
+  "processId" : "000003f1-a850-49de-af03-997272d834c9",
+  "scriptName" : "import",
+  "startTime" : "2017-11-22T10:29:11Z",
+  "status" : "RUNNING",
+  "_links" : {
+    "self" : {
+      "href" : "/api/admin/processes/000003f1-a850-49de-af03-997272d834c9"
+    }
+  }
+}
+```
+
+The possible `status` values are `RUNNING`, `STOPPED`, `FAILED` and `SCHEDULED`.

--- a/scripts-endpoint.md
+++ b/scripts-endpoint.md
@@ -6,7 +6,7 @@ DSpace has functionality to import and export items in CSV and ZIP format, to st
 ## Scripts Endpoint
 **GET /api/system/scripts**
 
-This endpoint will list all (REST supported) scripts defined in `dspace/config/launcher.xml`. The script entries are embedded with a name, description and a self link. By "REST supported" we mean all scripts that have been updated to allow invocations from the REST API.
+This endpoint will list all (REST supported) scripts defined in `dspace/config/spring/rest/scripts.xml`. The script entries are embedded with a name, description and a self link. By "REST supported" we mean all scripts that have been updated to allow invocations from the REST API.
 
 The JSON response document is as follows
 ```json
@@ -17,14 +17,11 @@ The JSON response document is as follows
       	"totalPages": 3,
       	"number": 0
   },
-  "sort" : {
-    "by" : "name",
-    "order" : "asc"
-  },
   "_embedded" : {
     "scripts" : [
       {
         "name" : "import",
+        "type" : "script",
         "description" : "Import items into DSpace",
         "_links" : {
           "self" : {
@@ -34,6 +31,7 @@ The JSON response document is as follows
       },
       {
         "name" : "metadata-import",
+        "type" : "script",
         "description" : "Import metadata after batch editing",
         "_links" : {
           "self" : {
@@ -58,80 +56,81 @@ The JSON response document is as follows
 {
    "name" : "import",
    "description" : "Import items into DSpace",
+   "type" : "script",
    "parameters" : [
     {
-      "name" : "a",
+      "name" : "-a",
       "description" : "add items to DSpace",
       "type" : "boolean"
     },
     {
-      "name" : "b",
+      "name" : "-b",
       "description" : "add items to DSpace via Biblio-Transformation-Engine (BTE)",
       "type" : "boolean"
     },
     {
-      "name" : "c",
+      "name" : "-c",
       "description" : "destination collection(s) database ID",
       "type" : "id"
     },
     {
-      "name" : "d",
+      "name" : "-d",
       "description" : "delete items listed in mapfile",
       "type" : "file"
     },
     {
-      "name" : "e",
+      "name" : "-e",
       "description" : "email of eperson doing importing",
       "type" : "string"
     },
     {
-      "name" : "i",
+      "name" : "-i",
       "description" : "input type in case of BTE import",
       "type" : "string"
     },
     {
-      "name" : "n",
+      "name" : "-n",
       "description" : "if sending submissions through the workflow, send notification emails",
       "type" : "boolean"
     },
     {
-      "name" : "p",
+      "name" : "-p",
       "description" : "apply template",
       "type" : "string"
     },
     {
-      "name" : "q",
+      "name" : "-q",
       "description" : "don't display metadata",
       "type" : "boolean"
     },
     {
-      "name" : "m",
+      "name" : "-m",
       "description" : "mapfile items in mapfile",
       "type" : "file"
     },
     {
-      "name" : "r",
+      "name" : "-r",
       "description" : "replace items in mapfile",
       "type" : "boolean"
     },
     {
-      "name" : "R",
+      "name" : "-R",
       "description" : "resume a failed import (add only)",
       "type" : "boolean"
     },
     {
-      "name" : "t",
+      "name" : "-t",
       "description" : "test run - do not actually import items",
       "type" : "boolean"
     },
     {
-      "name" : "w",
+      "name" : "-w",
       "description" : "send submission through collection's workflow",
       "type" : "boolean"
     },
     {
-      "name" : "z",
-      "description" : "zip file containig the import",
+      "name" : "-z",
+      "description" : "zip file containing the import",
       "type" : "file"
     }
    ]

--- a/scripts-endpoint.md
+++ b/scripts-endpoint.md
@@ -20,6 +20,7 @@ The JSON response document is as follows
   "_embedded" : {
     "scripts" : [
       {
+        "id" : "import",
         "name" : "import",
         "type" : "script",
         "description" : "Import items into DSpace",
@@ -54,6 +55,7 @@ This endpoint will return information on all the parameters that are required to
 The JSON response document is as follows
 ```json
 {
+   "id" : "import",
    "name" : "import",
    "description" : "Import items into DSpace",
    "type" : "script",

--- a/scripts-endpoint.md
+++ b/scripts-endpoint.md
@@ -4,11 +4,11 @@
 DSpace (6) has admin functionality to import and export items in CSV and ZIP format, to start a collection harvest run, to run or schedule curation tasks. Each of these functionalities also map on a DSpace CLI script. While we could implement each of these operations as a separate endpoint, this contract tries to describe a generic endpoint that allows administrators to explore, run or schedule DSpace CLI scripts from the REST API.
 
 ## Scripts Endpoint
-** GET /api/admin/scripts**
+**GET /api/admin/scripts**
 
 This endpoint will list all (REST supported) scripts defined in `dspace/config/launcher.xml`. The script entries are embedded with a name, description and a self link. By "REST supported" we mean all scripts that have been updated to allow invocations from the REST API.
 
-The JSON response document is as follow
+The JSON response document is as follows
 ```
 {
   "page": {
@@ -49,11 +49,11 @@ The JSON response document is as follow
 ## Script Name Endpoint
 
 ### Script Details
-** GET /api/admin/scripts/<:script-name>**
+**GET /api/admin/scripts/<:script-name>**
 
 This endpoint will return information on all the parameters that are required to invoke the script. This dependens on the parameters defined in the implementation of the script.
 
-The JSON response document is as follow
+The JSON response document is as follows
 ```
 {
    "name" : "import",
@@ -146,7 +146,7 @@ Following parameter types are available:
 * `output`: Parameters with this type define the name of the output file. This name can be used later to download the the output file (e.g. when running `export` or `metadata-export`).
 
 ### Script Invocation
-** POST /api/admin/scripts/<:script-name>**
+**POST /api/admin/scripts/<:script-name>**
 
 POST requests to this endpoint will start the corresponding script with the provided parameters. All parameter values should be provided in the body that has to use the `multipart/form-data` content type. Once the upload is complete and the script was started successfully, this endpoint will return details on the scripts execution
 


### PR DESCRIPTION
This is a contract proposal for https://jira.duraspace.org/browse/DS-3763

DSpace offers functionality like import and export of metadata and items, running curation tasks, running an OAI harvest from the web UI. While we can implement each of these features as a dedicated endpoint, I think it would require the same effort to implement one generic endpoint that is able to run (REST-enabled) DSpace CLI scripts for the REST API.

I'm very interested to hear your thoughts on this.
