### PR TITLE
align the contract to the name convention set in the java project

### DIFF
--- a/browses.md
+++ b/browses.md
@@ -56,10 +56,11 @@ It returns a collection of BrowseEntryResource the JSON document looks like
 ```json
 {
   "_embedded": {
-    "browseEntryResources": [
+    "browseEntries": [
       {
         "authority": null,
         "value": "Arulmozhiyal, Ramaswamy",
+        "type": "browseEntry",
         "valueLang": null,
         "count": 1,
         "_links": {


### PR DESCRIPTION
The BrowseEntry Resource defines a NAME constant with value BrowseEntry this imply that the resource collection endpoint should expose the list in the _embedded section using the browseEntries name.
This was previously ignored due to a bug in the JAVA implementation fixed in the commit
https://github.com/DSpace/DSpace/pull/1889/commits/e386f0d49ec04f528c5bfd8309143df75736a99f