### PR TITLE
Move item

### DIFF
--- a/items.md
+++ b/items.md
@@ -137,7 +137,7 @@ Example: <https://dspace7.4science.it/dspace-spring-rest/#https://dspace7.4scien
 
 It returns the collection where the item belong to
 
-**PUSH /api/core/items/<:uuid>/owningCollection/<:collection:uuid>**
+**PUT /api/core/items/<:uuid>/owningCollection/<:collection:uuid>**
 
 Example: <https://dspace7-internal.atmire.com/rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/owningCollection/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9>
 

--- a/items.md
+++ b/items.md
@@ -142,7 +142,7 @@ It returns the collection where the item belong to
 The actual collection is part of the body using the uri-list
 Example:
 
-```curl -i -X PUT "https://dspace7-internal.atmire.com/rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/owningCollection" -H "Content-Type:text/uri-list" -d "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9"```
+```curl -i -X PUT "https://dspace7.4science.it/dspace-spring-rest/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/owningCollection" -H "Content-Type:text/uri-list" -d "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/8e0928a0-047a-4369-8883-12669f32dd64"```
 
 It updates the owning collection (moves the item)
 

--- a/items.md
+++ b/items.md
@@ -137,9 +137,9 @@ Example: <https://dspace7.4science.it/dspace-spring-rest/#https://dspace7.4scien
 
 It returns the collection where the item belong to
 
-**PUT /api/core/items/<:uuid>/owningCollection/<:collection:uuid>**
+**PUT /api/core/items/<:uuid>/owningCollection?collection=<:collection:uuid>**
 
-Example: <https://dspace7-internal.atmire.com/rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/owningCollection/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9>
+Example: <https://dspace7-internal.atmire.com/rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/owningCollection?collection=16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9>
 
 It updates the owning collection (moves the item)
 

--- a/items.md
+++ b/items.md
@@ -137,11 +137,21 @@ Example: <https://dspace7.4science.it/dspace-spring-rest/#https://dspace7.4scien
 
 It returns the collection where the item belong to
 
-**PUT /api/core/items/<:uuid>/owningCollection?collection=<:collection:uuid>**
+**PUT /api/core/items/<:uuid>/owningCollection**
 
-Example: <https://dspace7-internal.atmire.com/rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/owningCollection?collection=16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9>
+The actual collection is part of the body using the uri-list
+Example:
+
+```curl -i -X PUT "https://dspace7-internal.atmire.com/rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/owningCollection" -H "Content-Type:text/uri-list" -d "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9"```
 
 It updates the owning collection (moves the item)
+
+Status codes:
+* 204 No content - if the operation succeeded
+* 401 Forbidden - if you are not authenticated
+* 403 Unauthorized - if you are not logged in with sufficient permissions
+* 404 Not found - if the item doesn't exist
+* 422 Unprocessable Entity - if the collection doesn't exist or the data cannot be resolved to a collection
 
 ### Template Item
 **/api/core/items/<:uuid>/templateItemOf**

--- a/items.md
+++ b/items.md
@@ -137,6 +137,12 @@ Example: <https://dspace7.4science.it/dspace-spring-rest/#https://dspace7.4scien
 
 It returns the collection where the item belong to
 
+**PUSH /api/core/items/<:uuid>/owningCollection/<:collection:uuid>**
+
+Example: <https://dspace7-internal.atmire.com/rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/owningCollection/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9>
+
+It updates the owning collection (moves the item)
+
 ### Template Item
 **/api/core/items/<:uuid>/templateItemOf**
 


### PR DESCRIPTION
This PR includes alterations to the items.md contract to add support for moving an item between collections.

The update currently uses PUT as a framework for PATCH is still in the works.