### PR TITLE
Small fix in the make "item private" curl example

### DIFF
--- a/items.md
+++ b/items.md
@@ -100,7 +100,7 @@ the reinstate operation will result in:
   "type": "item"
 ```
 
-To make an item private (or discoverable), `curl --data '{[ { "op": "replace", "path": "/discoverable", "value": false}]}' -X PATCH ${dspace7-url}/api/core/items/${item-uuid}`.  The discoverable operation also requires an Authorization header.
+To make an item private (or discoverable), `curl --data '[ { "op": "replace", "path": "/discoverable", "value": false}]' -H "Authorization: Bearer ..." -H "content-type: application/json" -X PATCH ${dspace7-url}/api/core/items/${item-uuid}`.  The discoverable operation also requires an Authorization header.
 
 
 For example, starting with the following item data:


### PR DESCRIPTION
There are a few very minor issues with the example curl request to make an item private. This PR addresses these issues. (Tested with curl 7.54.0)