### PR TITLE
DS-3908 Metadata patch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Returns whether the target resource is available.
 - `PUT`:
 Replaces the state of the target resource with the supplied request body. This updates the object (via full replacement). The updated information _must be included_ in the request body. An empty request body is not allowed, unless you are updating the object to be an empty object (with no attributes). Querystring parameters are not allowed, as `PUT` requests should always be performed on an existing object.
 
-- `PATCH`:
-Similar to PUT but partially updating the resources state. We adhere to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) see the [General rules for the Patch operation](patch.md) for more details.
+- `PATCH`
+Similar to PUT but partially updating the resources state. We adhere to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902).
+See [General rules for the Patch operation](patch.md) and [Modifying metadata via Patch](metadata-patch.md) for more details.
 
 - `DELETE`:
 Deletes the target resource (object).

--- a/bitstreams.md
+++ b/bitstreams.md
@@ -33,6 +33,10 @@ Exposed links:
 * format: link to the bitstream format resource associated with the bitstream (Adobe PDF, MS Word, etc.)
 * content: link to access the actual content of the bitstream
 
+## Patch operations
+
+Bitstream metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).
+
 ## Linked entities
 ### Format
 **/api/core/bitstreams/<:uuid>/format**

--- a/collections.md
+++ b/collections.md
@@ -90,6 +90,10 @@ Exposed links:
 * license: link to the license template used by the collection
 * defaultAccessConditions: link to the resource policies applied by default to new submissions in the collection
 
+## Patch operations
+
+Collection metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).
+
 ## Linked entities
 ### Logo
 **/api/core/collections/<:uuid>/logo**

--- a/communities.md
+++ b/communities.md
@@ -122,7 +122,6 @@ The supported parameters are:
 * **(mandatory)** parent, the UUID of the parent community
 * page, size [see pagination](README.md#Pagination)
 
-<<<<<<< HEAD
 ## Creating communities
 
 ### Creating top level community

--- a/communities.md
+++ b/communities.md
@@ -122,6 +122,7 @@ The supported parameters are:
 * **(mandatory)** parent, the UUID of the parent community
 * page, size [see pagination](README.md#Pagination)
 
+<<<<<<< HEAD
 ## Creating communities
 
 ### Creating top level community
@@ -213,3 +214,7 @@ Delete a community.
 * 401 Forbidden - if you are not authenticated
 * 403 Unauthorized - if you are not logged in with sufficient permissions
 * 404 Not found - if the community doesn't exist (or was already deleted)
+
+## Patch operations
+
+Community metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).

--- a/epersons.md
+++ b/epersons.md
@@ -9,6 +9,10 @@
 
 ## Patch operations
 
+EPerson metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).
+
+Additional properties can be modified via Patch as described below.
+
 ### Replace
 The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation to set not yet initialized information must return an error. See [general errors on PATCH requests](patch.md)
 

--- a/items.md
+++ b/items.md
@@ -152,6 +152,10 @@ Provide updated metadata information for an item, when the update is completed t
  
 ## Patch operations
 
+Item metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).
+
+Additional properties can be modified via Patch as described below.
+
 ### Replace
 The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation to set not yet initialized information must return an error. See [general errors on PATCH requests](patch.md)
 

--- a/metadata-patch.md
+++ b/metadata-patch.md
@@ -35,16 +35,24 @@ The examples in each section below build on each other, assuming an initial meta
 }
 ```
 
+Note: The metadata of items _in submission_ is modeled in the same way described here -- as a map
+of metadata keys to an ordered array of values. The primary difference is where the metadata
+is located within the JSON representation. The documentation and examples below apply to archived
+items and other DSpace object types, whereas the [WorkspaceItem Metadata](workspaceitem-data-metadata.md)
+document describes how item metadata can be modified during submission.
+
 ## Adding metadata
 
 With the `add` operation, you can add any number of metadata values in a single request.
 
 Note:
 
-* When no values exist yet for a metadata key, you must add the key and value array with one
-  or more values.
-* When values already exist for a metadata key, it is necessary to specify the new value's
-  position at the end of the `path` (`/0` means first position, `/-` means last).
+* According to the [JSON Patch specification](https://tools.ietf.org/html/rfc6902), to initialize the first
+  value for any array, the `add` operation must receive an array of values. Therefore, in the first operation
+  below, since it is not possible to add a single value to the not yet initialized `/metadata/dc.description`
+  array, we initialize it with an array with one value.
+* When values already exist for a metadata key, as in the second operation below, it is necessary to specify
+  the new value's position at the end of the `path` (`/0` means first position, `/-` means last).
 * When creating new metadata values, if unspecified, the `language` and `authority` properties
   default to `null`, and `confidence` defaults to `-1`.
 

--- a/metadata-patch.md
+++ b/metadata-patch.md
@@ -45,6 +45,13 @@ document describes how item metadata can be modified during submission.
 
 With the `add` operation, you can add any number of metadata values in a single request.
 
+You also use `add` to effectively _replace_ all values for a given metadata key, by specifying
+an already-present key as the `path`, and an array of your replacement values as the `value`.
+This use of the add operation to replace a list of values may be counter-intiutive, but it
+is done according to the [RFC section 4.1](https://tools.ietf.org/html/rfc6902#section-4.1)
+
+> If the target location specifies an object member that does exist, that member's value is replaced.
+
 Note:
 
 * According to the [JSON Patch specification](https://tools.ietf.org/html/rfc6902), to initialize the first

--- a/metadata-patch.md
+++ b/metadata-patch.md
@@ -1,0 +1,191 @@
+# Modifying metadata via Patch
+[Back to the index](README.md)
+
+**Contents:**
+
+* [Introduction](#introduction)
+* [Adding metadata](#adding-metadata)
+* [Removing metadata](#removing-metadata)
+* [Replacing metadata](#replacing-metadata)
+* [Ordering metadata](#ordering-metadata)
+
+## Introduction
+
+A user with write permission on a DSpace object may change any of its metadata
+using an HTTP PATCH request. All DSpace object types (Bitstreams, Items, Collections, etc.)
+support metadata changes in roughly the same way.
+
+This guide is focused on metadata-only changes and omits non-metadata parts of the object's
+json representation for brevity. However, you should be aware that PATCH requests operate
+against the whole object, and may therefore modify other mutable attributes in the same
+request.
+
+For additional information about PATCH support in DSpace, including request format and response
+status code details, see [General rules for the Patch operation](patch.md)
+
+The examples in each section below build on each other, assuming an initial metadata state of:
+
+```json
+{
+  "metadata": {
+    "dc.title": [
+      { "value": "Initial Title", "language": null, "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```
+
+## Adding metadata
+
+With the `add` operation, you can add any number of metadata values in a single request.
+
+Note:
+
+* When no values exist yet for a metadata key, you must add the key and value array with one
+  or more values.
+* When values already exist for a metadata key, it is necessary to specify the new value's
+  position at the end of the `path` (`/0` means first position, `/-` means last).
+* When creating new metadata values, if unspecified, the `language` and `authority` properties
+  default to `null`, and `confidence` defaults to `0`.
+
+Example request, adding three values:
+
+```json
+[
+  {
+    "op": "add",
+    "path": "/metadata/dc.description",
+    "value": [ { "value": "Some description" } ]
+  },
+  {
+    "op": "add",
+    "path": "/metadata/dc.title/0",
+    "value": { "value": "Zeroth Title" }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/dc.title/-",
+    "value": { "value": "Final Title", "language": "en_US" }
+  }
+]
+```
+
+New metadata state:
+
+```json
+{
+  "metadata": {
+    "dc.description": [
+      { "value": "Some description", "language": null, "authority": null, "confidence": -1 }
+    ],
+    "dc.title": [
+      { "value": "Zeroth Title", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Initial Title", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Final Title", "language": "en_US", "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```
+
+## Removing metadata
+
+With the `remove` operation, you can delete:
+
+* All metadata with a given key (e.g. `path="/metadata/dc.description"`)
+* A single metadata value with a known position (e.g. `path="/metadata/dc.title/0"`)
+
+When only one value is present for a particular key, it is functionally equivalent to
+specify the path to the key or the value.
+
+Example request, removing two values:
+
+```json
+[
+  {
+    "op": "remove",
+    "path": "/metadata/dc.description"
+  },
+  {
+    "op": "remove",
+    "path": "/metadata/dc.title/0"
+  }
+]
+```
+
+New metadata state:
+
+```json
+{
+  "metadata": {
+    "dc.title": [
+      { "value": "Initial Title", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Final Title", "language": "en_US", "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```
+
+## Replacing metadata
+
+With `replace`, you can overwrite any of the following within a single operation
+of a PATCH request:
+
+* The entire set of all object metadata (`path="/metadata"`)
+* All metadata values for an existing key (e.g. `path="/metadata/dc.title"`)
+* A single existing metadata value (e.g. `path="/metadata/dc.title/0"`)
+* A single property of an existing value (e.g. `path="/metadata/dc.title/0/language"`)
+
+Example request, replacing the `value` and `language` of the first `dc.title`:
+
+```json
+[
+  {
+    "op": "replace",
+    "path": "/metadata/dc.title/0/value",
+    "value": "最後のタイトル"
+  },
+  {
+    "op": "replace",
+    "path": "/metadata/dc.title/0/language",
+    "value": "ja_JP"
+  }
+]
+```
+
+```json
+{
+  "metadata": {
+    "dc.title": [
+      { "value": "最後のタイトル", "language": "ja_JP", "authority": null, "confidence": -1 },
+      { "value": "Final Title", "language": "en_US", "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```
+
+## Ordering metadata
+
+Metadata may be re-ordered with the `move` operation.
+
+Example request, moving the last `dc.title` value to the first position:
+
+```json
+[
+  {
+    "op": "move",
+    "from": "/metadata/dc.title/1",
+    "path": "/metadata/dc.title/0"
+  }
+]
+```
+
+```json
+{
+  "metadata": {
+    "dc.title": [
+      { "value": "Final Title", "language": "en_US", "authority": null, "confidence": -1 },
+      { "value": "最後のタイトル", "language": "ja_JP", "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```

--- a/metadata-patch.md
+++ b/metadata-patch.md
@@ -46,7 +46,7 @@ Note:
 * When values already exist for a metadata key, it is necessary to specify the new value's
   position at the end of the `path` (`/0` means first position, `/-` means last).
 * When creating new metadata values, if unspecified, the `language` and `authority` properties
-  default to `null`, and `confidence` defaults to `0`.
+  default to `null`, and `confidence` defaults to `-1`.
 
 Example request, adding three values:
 
@@ -152,6 +152,8 @@ Example request, replacing the `value` and `language` of the first `dc.title`:
 ]
 ```
 
+New metadata state:
+
 ```json
 {
   "metadata": {
@@ -178,6 +180,8 @@ Example request, moving the last `dc.title` value to the first position:
   }
 ]
 ```
+
+New metadata state:
 
 ```json
 {

--- a/metadata-patch.md
+++ b/metadata-patch.md
@@ -149,13 +149,8 @@ Example request, replacing the `value` and `language` of the first `dc.title`:
 [
   {
     "op": "replace",
-    "path": "/metadata/dc.title/0/value",
-    "value": "最後のタイトル"
-  },
-  {
-    "op": "replace",
-    "path": "/metadata/dc.title/0/language",
-    "value": "ja_JP"
+    "path": "/metadata/dc.title/0",
+    "value": { "value": "最後のタイトル", "language": "ja_JP" }
   }
 ]
 ```

--- a/workspaceitem-data-metadata.md
+++ b/workspaceitem-data-metadata.md
@@ -1,36 +1,36 @@
 # WorkspaceItem data of submission-form sectionType
 [Back to the definition of the workspaceitems endpoint](workspaceitems.md)
 
-The section data represent the metadata collected for a specific [submissionform](submissionforms.md) it is a json object with the following structure
+The section data represent the metadata collected for a specific [submissionform](submissionforms.md).
+It is a json object with the following structure:
 
 ```json
-      "dc.contributor.author": [
-        {
-          "value": "Bollini, Andrea",
-          "language": null,
-          "authority": "rp00001",
-          "confidence": 600,
-          "place": 0
-        }
-      ],
-      "dc.title": [
-        {
-          "value": "Sample Submission Item",
-          "language": "en_US",
-          "authority": null,
-          "confidence": -1,
-          "place": 0
-        }
-      ],
-      "dc.date.issued": [
-        {
-          "value": "test",
-          "language": null,
-          "authority": null,
-          "confidence": -1,
-          "place": 0
-        }
-      ]   
+{
+  "dc.contributor.author": [
+    {
+      "value": "Bollini, Andrea",
+      "language": null,
+      "authority": "rp00001",
+      "confidence": 600
+    }
+  ],
+  "dc.title": [
+    {
+      "value": "Sample Submission Item",
+      "language": "en_US",
+      "authority": null,
+      "confidence": -1
+    }
+  ],
+  "dc.date.issued": [
+    {
+      "value": "test",
+      "language": null,
+      "authority": null,
+      "confidence": -1
+    }
+  ]   
+}
 ```
 
 The attribute name is the metadata key using the '.' dot separator (i.e. dc.title, dc.contributor.author, etc.) the value is an array, sorted by the metadatavalue.place column, containing
@@ -38,6 +38,12 @@ The attribute name is the metadata key using the '.' dot separator (i.e. dc.titl
 * authority: the authority key if any associated
 * confidence: the level of confidence for the authority if any, -1 otherwise
 * language: the iso code associated with the textual value if any
+
+Note: The metadata of _archived_ items is modeled in the same way described here -- as a map
+of metadata keys to an ordered array of values. The primary difference is where the metadata
+is located within the JSON representation. The documentation and examples below apply to
+items during submission, whereas the [Modifying Metadata via PATCH](metadata-patch.md)
+document describes how they can be modified _after_ they have been archived.
 
 ## Patch operations
 The PATCH method expects a JSON body according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902)


### PR DESCRIPTION
This adds contract docs for metadata PATCH support.

https://jira.duraspace.org/browse/DS-3908

It mainly just adds this document and links to it from appropriate places: https://github.com/DSpace/Rest7Contract/blob/0f04637d0ca16e42ad1fcce251e17db49b0fb701/metadata-patch.md

REST implementation PR: https://github.com/DSpace/DSpace/pull/2313