### PR TITLE
Add Design Principles, terminology, examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,23 @@ This type of endpoint interacts with (one or more) resources that are *associate
 Returns the state of the association (for the current resource)
 
 - `PUT`:
-Binds (or links) the resource(s) pointed to by the given URI(s) to the current resource. Resource URIs to link must sent in the body of the request using `Content-Type:text/uri-list`. [See example from Spring Data REST Relationships](https://www.baeldung.com/spring-data-rest-relationships). Return `400 Bad Request` if multiple URIs were given for a *-to-one-association
+Binds (or links) the resource(s) pointed to by the given URI(s) to the current resource. This replaces any existing links with the URIs passed in the request. Resource URIs to link must be sent in the body of the request using `Content-Type:text/uri-list`. [See example from Spring Data REST Relationships](https://www.baeldung.com/spring-data-rest-relationships). Return `400 Bad Request` if multiple URIs were given for a *-to-one-association
+   ```
+   # Example curl command to replace Item-to-Collection mappings with the two listed
+   # Notice the two Collection URIs are separated by a newline (\n)
+   curl -i -X PUT "http://localhost:8080/rest/api/core/items/<:uuid>/mappedCollections" 
+        -H "Content-Type:text/uri-list" 
+        -d "http://localhost:8080/rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb \n http://localhost:8080/rest/api/core/collections/5ad50035-ca22-4a4d-84ca-d5132f34f588"
+   ```
 
 - `POST`:
 Only supported for collection associations (i.e. associations allowing for multiple resources). Adds/Links a new resource (via its URI) to the association. Resource URIs to link must sent in the body of the request using `Content-Type:text/uri-list`. [See example from Spring Data REST Relationships](https://www.baeldung.com/spring-data-rest-relationships)
+   ```
+   # Example curl command to add a *new* Collection mapping for an Item
+   curl -i -X POST "http://localhost:8080/rest/api/core/items/<:uuid>/mappedCollections" 
+        -H "Content-Type:text/uri-list" 
+        -d "http://localhost:8080/rest/api/core/collections/5ad50035-ca22-4a4d-84ca-d5132f34f588"
+   ```
 
 - `DELETE`:
 Unbinds (unlinks) the association. Return `405 Method Not Allowed` if the association is required (and cannot be removed)
@@ -85,7 +98,7 @@ Unbinds (unlinks) the association. Return `405 Method Not Allowed` if the associ
 
 403 Forbidden - if the requester doesn't have enough privilege to execute the request
 
-404 Not Found - if the requested entity or collection doesn't exists
+404 Not Found - if the requested entity or collection doesn't exist
 
 405 Method Not Allowed - if the methods is not implemented or a DELETE method is called on a non-optional association
 
@@ -156,14 +169,14 @@ The REST API supports the [HATEOAS paradigm](https://restfulapi.net/hateoas/) an
 Because the API responds using the HAL Format, we distribute it with an [embedded HAL Browser provided by Spring](https://docs.spring.io/spring-data/rest/docs/current/reference/html/#_the_hal_browser).
 
 ### Statelessness
-The REST API is [stateless](https://restfulapi.net/statelessness/), meaning the client is responsible for sending any state information to the server when it is needed (there is no session kept on the server between requests).
+The REST API is considered [stateless](https://restfulapi.net/statelessness/), meaning the client is responsible for keeping state information and sending it to the server when it is needed. Because the server stores no state (or session) information internally, it will return a "token" (which contains any state information) to the client. The client must then return that token in *each subsequent request*, if the client wants that state information preserved.
 
 #### JSON Web Tokens
-[JSON Web Tokens (JWT)](https://jwt.io/) are used to retain state (and authentication) information between requests.
+[JSON Web Tokens (JWT)](https://jwt.io/) are used to store state (and authentication) information between requests. This is the format of token the REST API returns to the client. The client should return the JWT to the server in subsequent requests.
 
 ### ALPS - Application Level Profile Semantics
-While not yet implemented, we expect future support for the ALPS metadata (<http://alps.io/>), so a profile link MUST exists from the root of API.
-A profile link as defined in [RFC 6906](<https://tools.ietf.org/html/rfc6906>), is a place to include application level details. The ALPS draft spec (http://tools.ietf.org/html/draft-amundsen-richardson-foster-alps-00)
+**While not yet implemented**, we expect future support for the ALPS metadata (<http://alps.io/>), so a profile link MUST exists from the root of API.
+A profile link as defined in [RFC 6906](<https://tools.ietf.org/html/rfc6906>), is a place to include application level details. See the ALPS draft spec (http://tools.ietf.org/html/draft-amundsen-richardson-foster-alps-00)
 
 ### Spring Technology alignment
 While it's an implementation detail, the new REST API uses many Spring REST (Java) libraries, including:

--- a/README.md
+++ b/README.md
@@ -27,52 +27,70 @@ Repository to discuss the new REST API contract for DSpace 7. The code to implem
 
 ## Use of the HTTP Verbs and HTTP Response CODE
 
+_Please note that within this section, all terms used are meant to reference RESTful terminology and/or terminology borrowed from [Spring Data REST](https://docs.spring.io/spring-data/rest/docs/current/reference/html/#repository-resources)._ 
+ - `resource` - anything that can be identified via a URI. It's a representation of an underlying object. e.g. `/items/123-456-789` is a resource that represents a single DSpace Item. For additional examples see https://restful-api-design.readthedocs.io/en/latest/resources.html
+ - `object` - we use this term to mean the actual object *behind* the resource. In other words, a resource is a JSON representation of some object (often a DSpaceObject) stored in the database. This is also sometimes called an "entity".
+ - `collection` - a group of resources e.g. `/items` is a collection of all DSpace Item resources. This is also sometimes called a "collection resource" (e.g. in Spring Data REST)
+     - Somewhat confusingly, Spring Data REST likes to use the phrase "item resources" for individual resources within a collection. Below, we've just called them "resources".
+ - `association` - a link or relationship between two resources. This is also sometimes called an "association resource" (e.g. in Spring Data REST).
+ 
 ### On collection of resources endpoints
+
+Collection Of Resources Example: `/items`
+
 - POST
-Adds a new element to the collection.
+Adds a new resource to the collection. This creates a new object.
 
 - GET
 Returns the first page of the resources in the collection
 
 ### On single resource endpoints
+
+Single Resource Example: `/items/123-456-789`
+
 - GET
-Returns a single entity.
+Returns a single resource.
 
 - HEAD
-Returns whether the item resource is available.
+Returns whether the target resource is available.
 
 - PUT
-Replaces the state of the target resource with the supplied request body.
+Replaces the state of the target resource with the supplied request body. This updates the object (via full replacement)
 
 - PATCH
 Similar to PUT but partially updating the resources state. We adhere to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) see the [General rules for the Patch operation](patch.md) for more details.
 
 - DELETE
-Deletes the resource exposed.
+Deletes the target resource and object.
 
-### On sub-path of a single resource endpoint)
+### On sub-path of a single resource endpoint
+
+Sub-path of Single Resource Example: `/items/123-456-789/mappedCollections`
+
 - GET
-Returns the state of the association resource
+Returns the state of the association (for the single resource)
 
 - PUT
-Binds the resource pointed to by the given URI(s) to the resource. Return 400 Bad Request if multiple URIs were given for a to-one-association
+Binds (or links) the resource(s) pointed to by the given URI(s) to the single resource. Return 400 Bad Request if multiple URIs were given for a *-to-one-association
 
 - POST
-Only supported for collection associations. Adds a new element to the collection.
+Only supported for collection associations. Adds a new resource to the collection.
 
 - DELETE
-Unbinds the association. Return 405 Method Not Allowed if the association is non-optional
+Unbinds (unlinks) the association. Return 405 Method Not Allowed if the association is required (and cannot be removed)
 
 ### Error codes
 400 Bad Request - if multiple URIs were given for a to-one-association
 
-401 Unauthenticated - if the request require a logged-in user
+401 Unauthorized (Unauthenticated) - if the request requires a logged-in user
 
-403 Unauthorized - if the requester doesn't have enough privilege to execute the request
+403 Forbidden - if the requester doesn't have enough privilege to execute the request
 
-404 Not found - if the requested entity or collection doesn't exists
+404 Not Found - if the requested entity or collection doesn't exists
 
-405 Method Not Allowed - if the methods is not implemented or a DELETE methods is called on a non-optional association
+405 Method Not Allowed - if the methods is not implemented or a DELETE method is called on a non-optional association
+
+422 Unprocessable Entity - if the request is well-formed, but is invalid based on the given data. For example, if you attempt to create a resource under a non-existent parent resource, or attempt to update a read-only (non-editable) field.
 
 ## On the Naming of Endpoints
 Names should be descriptive but reasonably short.  Form compounds by concatenating words, all lower case, without punctuation.  For example:  `metadatafields`, not `metadata-fields` or `MetadataFields`.

--- a/README.md
+++ b/README.md
@@ -35,48 +35,48 @@ _Please note that within this section, all terms used are meant to reference RES
  
 ### On collection of resources endpoints
 
-Collection Of Resources Example: `/api/core/items`
+This type of endpoint interacts with a group (or collection) of resources (objects). For example: `/api/core/items` references *all* Items in the system. 
 
-- POST
-Adds a new resource to the collection. This creates a new object. The data for the new object _should be included_ in the request body.
+- `POST`:
+Adds a new resource to the group (or collection). This creates a new object. The data for the new object _should be included_ in the request body. Related or additional information (such as required associations to other objects) may be passed as querystring parameters in the request, _if it is required to create the object._
 
-- GET
-Returns the first page of the resources in the collection
+- `GET`:
+Returns the first page of the resources in the group (or collection). See [Pagination](#pagination) section. 
 
 ### On single resource endpoints
 
-Single Resource Example: `/api/core/items/123-456-789`
+This type of endpoint interacts with a single resource (object). For example: `/api/core/items/123-456-789` references a single Item.
 
-- GET
+- `GET`:
 Returns a single resource.
 
-- HEAD
+- `HEAD`:
 Returns whether the target resource is available.
 
-- PUT
-Replaces the state of the target resource with the supplied request body. This updates the object (via full replacement). The updated information _should be included_ in the request body.
+- `PUT`:
+Replaces the state of the target resource with the supplied request body. This updates the object (via full replacement). The updated information _should be included_ in the request body. Related or additional information (such as required associations to other objects) may be passed as querystring parameters in the request, _if it is necessary to update the object._
 
-- PATCH
+- `PATCH`:
 Similar to PUT but partially updating the resources state. We adhere to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) see the [General rules for the Patch operation](patch.md) for more details.
 
-- DELETE
+- `DELETE`:
 Deletes the target resource and object.
 
-### On sub-path of a single resource endpoint
+### On sub-path of a single resource endpoint (associations)
 
-Sub-path of Single Resource Example: `/api/core/items/123-456-789/mappedCollections`
+This type of endpoint interacts with (one or more) resources that are *associated with* a single resource. For that reason, it is sometimes called an "association" endpoint. For example: `/api/core/items/123-456-789/mappedCollections` references all Collections that are mapped to a single Item.
 
-- GET
-Returns the state of the association (for the single resource)
+- `GET`:
+Returns the state of the association (for the current resource)
 
-- PUT
-Binds (or links) the resource(s) pointed to by the given URI(s) to the single resource. Return 400 Bad Request if multiple URIs were given for a *-to-one-association
+- `PUT`:
+Binds (or links) the resource(s) pointed to by the given URI(s) to the current resource. Resource URIs to link must sent in the body of the request using `Content-Type:text/uri-list`. [See example from Spring Data REST Relationships](https://www.baeldung.com/spring-data-rest-relationships). Return `400 Bad Request` if multiple URIs were given for a *-to-one-association
 
-- POST
-Only supported for collection associations. Adds a new resource to the collection.
+- `POST`:
+Only supported for collection associations (i.e. associations allowing for multiple resources). Adds/Links a new resource (via its URI) to the association. Resource URIs to link must sent in the body of the request using `Content-Type:text/uri-list`. [See example from Spring Data REST Relationships](https://www.baeldung.com/spring-data-rest-relationships)
 
-- DELETE
-Unbinds (unlinks) the association. Return 405 Method Not Allowed if the association is required (and cannot be removed)
+- `DELETE`:
+Unbinds (unlinks) the association. Return `405 Method Not Allowed` if the association is required (and cannot be removed)
 
 ### Error codes
 400 Bad Request - if multiple URIs were given for a to-one-association

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ Repository to discuss the new REST API contract for DSpace 7. The code to implem
 ## Use of the HTTP Verbs and HTTP Response CODE
 
 _Please note that within this section, all terms used are meant to reference RESTful terminology and/or terminology borrowed from [Spring Data REST](https://docs.spring.io/spring-data/rest/docs/current/reference/html/#repository-resources)._ 
- - `resource` - anything that can be identified via a URI. It's a representation of an underlying object. e.g. `/items/123-456-789` is a resource that represents a single DSpace Item. For additional examples see https://restful-api-design.readthedocs.io/en/latest/resources.html
- - `object` - we use this term to mean the actual object *behind* the resource. In other words, a resource is a JSON representation of some object (often a DSpaceObject) stored in the database. This is also sometimes called an "entity".
+ - `resource` - anything that can be identified via a URI. It's a representation of an underlying object. e.g. `/items/123-456-789` is a resource that represents a single DSpace Item object. For additional examples see https://restful-api-design.readthedocs.io/en/latest/resources.html
+ - `object` - we use this term to mean the actual object *behind* the resource. In other words, a resource is a JSON representation of some object (often a DSpaceObject) stored in the database. This is also sometimes called an "entity" in REST terminology.
  - `collection` - a group of resources e.g. `/items` is a collection of all DSpace Item resources. This is also sometimes called a "collection resource" (e.g. in Spring Data REST)
-     - Somewhat confusingly, Spring Data REST likes to use the phrase "item resources" for individual resources within a collection. Below, we've just called them "resources".
+     - Be aware that the term "collection" in this document has nothing to do with a DSpace Collection object. In REST terminology, a "collection" endpoint is simply an endpoint that returns multiple resources (objects), often in a paginated list.
+     - NOTE: Spring Data REST likes to use the phrase "item resources" for individual resources within a "collection resource". We've simplified this terminology and just call them "resources" and "collections", respectively.
  - `association` - a link or relationship between two resources. This is also sometimes called an "association resource" (e.g. in Spring Data REST).
  
 ### On collection of resources endpoints
@@ -183,7 +184,7 @@ The REST API is considered [stateless](https://restfulapi.net/statelessness/), m
 [JSON Web Tokens (JWT)](https://jwt.io/) are used to store state (and authentication) information between requests. This is the format of token the REST API returns to the client. The client should return the JWT to the server in subsequent requests.
 
 ### ALPS - Application Level Profile Semantics
-**While not yet implemented**, we expect future support for the ALPS metadata (<http://alps.io/>), so a profile link MUST exists from the root of API.
+**While not yet implemented**, we expect future support for the ALPS metadata (<http://alps.io/>), so a profile link MUST exist from the root of API.
 A profile link as defined in [RFC 6906](<https://tools.ietf.org/html/rfc6906>), is a place to include application level details. See the ALPS draft spec (http://tools.ietf.org/html/draft-amundsen-richardson-foster-alps-00)
 
 ### Spring Technology alignment

--- a/README.md
+++ b/README.md
@@ -35,17 +35,25 @@ _Please note that within this section, all terms used are meant to reference RES
  
 ### On collection of resources endpoints
 
-This type of endpoint interacts with a group (or collection) of resources (objects). For example: `/api/core/items` references *all* Items in the system. 
+This type of endpoint interacts with a group (or collection) of resources (objects). For example: `/api/core/items` references *all* Items in the system.
 
 - `POST`:
-Adds a new resource to the group (or collection). This creates a new object. The data for the new object _should be included_ in the request body. Related or additional information (such as required associations to other objects) may be passed as querystring parameters in the request, _if it is required to create the object._
+Creates a new resource (object) and adds it to the group. Any required data (i.e. attributes) for the new object _must be included_ in the request body. An empty request body is not allowed, unless you are creating an empty object with no attributes.
+    - Related or additional information (such as required associations to other objects) may be passed as querystring parameters in the request, _if it is required to create the object._
+        ```
+        # For example, creating a Collection *requires* linking it to a parent Community
+        # In this scenario, we must have a querystring param to specify the parent Community UUID
+        curl -i -X POST "http://localhost:8080/rest/api/core/collections?parent=<:communityUUID>" 
+            -H "Content-Type:application/json" 
+            -d "[{ ... attributes of new Collection ... }]"
+        ```
 
 - `GET`:
 Returns the first page of the resources in the group (or collection). See [Pagination](#pagination) section. 
 
 ### On single resource endpoints
 
-This type of endpoint interacts with a single resource (object). For example: `/api/core/items/123-456-789` references a single Item.
+This type of endpoint interacts with a single, existing resource (object). For example: `/api/core/items/<:uuid>` references a single Item resource.
 
 - `GET`:
 Returns a single resource.
@@ -54,17 +62,17 @@ Returns a single resource.
 Returns whether the target resource is available.
 
 - `PUT`:
-Replaces the state of the target resource with the supplied request body. This updates the object (via full replacement). The updated information _should be included_ in the request body. Related or additional information (such as required associations to other objects) may be passed as querystring parameters in the request, _if it is necessary to update the object._
+Replaces the state of the target resource with the supplied request body. This updates the object (via full replacement). The updated information _must be included_ in the request body. An empty request body is not allowed, unless you are updating the object to be an empty object (with no attributes). Querystring parameters are not allowed, as `PUT` requests should always be performed on an existing object.
 
 - `PATCH`:
 Similar to PUT but partially updating the resources state. We adhere to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) see the [General rules for the Patch operation](patch.md) for more details.
 
 - `DELETE`:
-Deletes the target resource and object.
+Deletes the target resource (object).
 
 ### On sub-path of a single resource endpoint (associations)
 
-This type of endpoint interacts with (one or more) resources that are *associated with* a single resource. For that reason, it is sometimes called an "association" endpoint. For example: `/api/core/items/123-456-789/mappedCollections` references all Collections that are mapped to a single Item.
+This type of endpoint interacts with (one or more) resources that are *associated with* a single resource. For that reason, it is sometimes called an "association" endpoint. For example: `/api/core/items/<:uuid>/mappedCollections` references all Collections that are mapped to a single Item resource.
 
 - `GET`:
 Returns the state of the association (for the current resource)


### PR DESCRIPTION
This is the beginnings of some cleanup to the REST Contract README.  Once reviewed/approved, it can be merged as-is (and I can always follow-up with more PRs).

Mostly, this tries to better define the terminology used (resource, collection, object, association) in our contract. It also documents the `422` response code (which was requested in PR #33 comments)