### PR TITLE
[DS-4062] Endpoint for eperson profile patches

### DIFF
--- a/epersons.md
+++ b/epersons.md
@@ -12,8 +12,9 @@
 ### Replace
 The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation to set not yet initialized information must return an error. See [general errors on PATCH requests](patch.md)
 
+#### These operations can be performed by administrators.
 
-To replace the certificate required value, `curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/certificate", "value": "true|false"]'`.  The operation also requires an Authorization header.
+To replace the certificate required value, `curl -X PATCH http://${dspace.url}/api/eperson/epersons/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/certificate", "value": "true|false"]'`.  The operation also requires an Authorization header.
 
 For example, starting with the following eperson field data:
 ```json
@@ -24,7 +25,7 @@ the replace operation `[{ "op": "replace", "path": "/certificate", "value": "fal
   "requireCerticate": false,
 ```
 
-To replace the canLogin value, `curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/canLogin", "value": "true|false"]'`.  The operation also requires an Authorization header.
+To replace the canLogin value, `curl -X PATCH http://${dspace.url}/api/eperson/epersons/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/canLogin", "value": "true|false"]'`.  The operation also requires an Authorization header.
 
 For example, starting with the following eperson field data:
 ```json
@@ -34,7 +35,7 @@ the replace operation `[{ "op": "replace", "path": "/canLogin", "value": "false"
 ```json
   "canLogIn": false,
 ```
-To replace the netid value, `curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/netid", "value": "newNetId"]'`.  The operation also requires an Authorization header.
+To replace the netid value, `curl -X PATCH http://${dspace.url}/api/eperson/epersons/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/netid", "value": "newNetId"]'`.  The operation also requires an Authorization header.
 
 For example, starting with the following eperson field data:
 ```json
@@ -45,7 +46,20 @@ the replace operation `[{ "op": "replace", "path": "/netid", "value": "newNetId"
   "netid": "newNetId",
 ```
 
-To replace the password value, `curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/password", "value": "newpassword"]'`.  The operation also requires an Authorization header.
+To replace the email value, `curl -X PATCH http://${dspace.url}/api/eperson/epersons/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/email", "value": "new@email"]'`.  The operation also requires an Authorization header.
+
+For example, starting with the following eperson field data:
+```json
+ "email": "old@email",
+```
+the replace operation `[{ "op": "replace", "path": "/email", "value": "new@email"]` will result in :
+```json
+  "email": "new@email",
+  ```
+  
+#### This operation can be performed by administrators and by the authenticated user.
+
+To replace the password value, `curl -X PATCH http://${dspace.url}/api/eperson/epersons/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/password", "value": "newpassword"]'`.  The operation also requires an Authorization header.
 
 For example, starting with the following eperson field data:
 ```json
@@ -55,4 +69,4 @@ the replace operation `[{ "op": "replace", "path": "/password", "value": "newpas
 ```json
   "password": "newpassword",
 ```
-Note: The new password is currently returned after an update but this could be revisited later, see [#30]((https://github.com/DSpace/Rest7Contract/issues/30))
+NOTE: The new password is currently returned after an update but this could be revisited later, see [#30]((https://github.com/DSpace/Rest7Contract/issues/30))


### PR DESCRIPTION
This is related to https://github.com/DSpace/DSpace/pull/2257, which gives logged in users the ability to update their eperson profile. That includes the ability to update metadata on the eperson DSO.

Both PR's appear to be in conflict with https://github.com/DSpace/Rest7Contract/pull/46 and work on metadata patches by cwilper. If that approach is taken then I think this PR (and it's related PR) will become smaller in scope, since the only new feature provided is giving logged in users the ability to change their password.