### PR TITLE
Mapping collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Only supported for collection associations (i.e. associations allowing for multi
    ```
 
 - `DELETE`:
-Unbinds (unlinks) the association. Return `405 Method Not Allowed` if the association is required (and cannot be removed)
+Unbinds (unlinks) the association. Return `405 Method Not Allowed` if the association is required (and cannot be removed).  DELETE requests should _not_ contain a body as some clients do not support sending a DELETE request with a body. Therefore, if an individual association needs to be removed, the DELETE request should include the association ID in the URI of the request.
 
 ### Error codes
 400 Bad Request - if multiple URIs were given for a to-one-association

--- a/README.md
+++ b/README.md
@@ -98,7 +98,15 @@ Only supported for collection associations (i.e. associations allowing for multi
    ```
 
 - `DELETE`:
-Unbinds (unlinks) the association. Return `405 Method Not Allowed` if the association is required (and cannot be removed).  DELETE requests should _not_ contain a body as some clients do not support sending a DELETE request with a body. Therefore, if an individual association needs to be removed, the DELETE request should include the association ID in the URI of the request.
+Unbinds (unlinks) the association. Return `405 Method Not Allowed` if the association is required (and cannot be removed).  DELETE requests should _not_ contain a request body as some clients do not support sending a DELETE request with a body. Therefore, if an individual association needs to be removed, the DELETE request should reference that individual association in the URI of the request. For example:
+   ```
+   # Example curl command to delete a *single* Collection mapping for an Item
+   curl -i -X DELETE "http://localhost:8080/rest/api/core/items/<:uuid>/mappedCollections/<:collection_uuid>"
+   
+   # Example curl command to delete *ALL* Collection mappings for an item (unsupported at this time)
+   curl -i -X DELETE "http://localhost:8080/rest/api/core/items/<:uuid>/mappedCollections
+   ```
+
 
 ### Error codes
 400 Bad Request - if multiple URIs were given for a to-one-association

--- a/items.md
+++ b/items.md
@@ -401,12 +401,12 @@ On the item page, it should be referenced similar to:
     }
 ```
 
-**POST /api/core/items/<item:uuid>/mappingCollections/<collection:uuid>**
+**POST /api/core/items/<item:uuid>/mappingCollections?collection=<collection:uuid>**
 
 A POST request will result in creating a new mapping between the item and collection
 If the collection exists and is neither the owning nor mapping collection for the item, the relation should be created
 
-**DELETE /api/core/items/<item:uuid>/mappingCollections/<collection:uuid>**
+**DELETE /api/core/items/<item:uuid>/mappingCollections?collection=<collection:uuid>**
 
 A DELETE request will result in removing an existing mapping between the item and collection
 If the collection exists and is a mapping collection for the item, the relation should be deleted

--- a/items.md
+++ b/items.md
@@ -246,7 +246,7 @@ Status codes:
 * 422 Unprocessable Entity - if the collection doesn't exist or the data cannot be resolved to a collection
 
 ### Mapping Collections
-**/api/core/items/<:uuid>/mappingCollections**
+**GET /api/core/items/<:uuid>/mappingCollections**
 
 Example:
 ```json
@@ -400,6 +400,16 @@ On the item page, it should be referenced similar to:
       "href": "https://dspace7-internal.atmire.com/rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/mappingCollections"
     }
 ```
+
+**POST /api/core/items/<item:uuid>/mappingCollections/<collection:uuid>**
+
+A POST request will result in creating a new mapping between the item and collection
+If the collection exists and is neither the owning nor mapping collection for the item, the relation should be created
+
+**DELETE /api/core/items/<item:uuid>/mappingCollections/<collection:uuid>**
+
+A DELETE request will result in removing an existing mapping between the item and collection
+If the collection exists and is a mapping collection for the item, the relation should be deleted
 
 ### Template Item
 **/api/core/items/<:uuid>/templateItemOf**

--- a/items.md
+++ b/items.md
@@ -283,12 +283,16 @@ Return codes:
 
 **PUT /api/core/items/<:uuid>/mappedCollections**
 
-PUT is NOT SUPPORTED at this time. You may replace or update mapped collections using DELETE requests and/or POST requests.
+_Unsupported._ You may replace or update mapped collections using DELETE requests and/or POST requests.
+
+**DELETE /api/core/items/<:uuid>/mappedCollections**
+
+_Unsupported._ At this time, we do not support removing all mapped Collections in a single request. Please use `DELETE /api/core/items/<:uuid>/mappedCollections/<:collection_uuid>` to remove mapped Collections one by one.
 
 **DELETE /api/core/items/<:uuid>/mappedCollections/<:collection_uuid>**
 
-A DELETE request will result in removing an existing mapping between the item and collection
-If the collection exists and is a mapped collection for the item, the relation should be deleted
+A DELETE request will result in removing an existing mapping between the item and collection.
+If the collection exists and is a mapped collection for the item, the relation should be deleted.
 
 ```
  curl -i -X DELETE https://dspace7.4science.it/dspace-spring-rest/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"

--- a/items.md
+++ b/items.md
@@ -249,148 +249,7 @@ Status codes:
 ### Mapped Collections
 **GET /api/core/items/<:uuid>/mappedCollections**
 
-Example:
-```json
-    "mappedCollections":
-    [
-      {
-        "id": "16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9",
-        "uuid": "16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9",
-        "name": "Bachelor theses",
-        "handle": "123456789/5287",
-        "metadata": [
-          {
-            "key": "dc.description.abstract",
-            "value": "",
-            "language": null
-          },
-          {
-            "key": "dc.title",
-            "value": "Bachelor theses",
-            "language": null
-          }
-        ],
-        "type": "collection",
-        "_links": {
-          "license": {
-            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/license"
-          },
-          "defaultAccessConditions": {
-            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/defaultAccessConditions"
-          },
-          "logo": {
-            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/logo"
-          },
-          "self": {
-            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9"
-          }
-        },
-        "_embedded": {
-          "logo": null,
-          "defaultAccessConditions": {
-            "_embedded": {
-              "defaultAccessConditions": [
-                {
-                  "id": 28054,
-                  "name": null,
-                  "groupUUID": "9e1794b8-45e0-4869-9c2c-36c4b25ce856",
-                  "action": "DEFAULT_BITSTREAM_READ",
-                  "type": "resourcePolicy",
-                  "_links": {
-                    "self": {
-                      "href": "https://dspace7.4science.it/dspace-spring-rest/api/authz/resourcePolicies/28054"
-                    }
-                  }
-                }
-              ]
-            },
-            "_links": {
-              "self": {
-                "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/defaultAccessConditions"
-              }
-            },
-            "page": {
-              "number": 0,
-              "size": 1,
-              "totalPages": 1,
-              "totalElements": 1
-            }
-          }
-        }
-      },
-      {
-        "id": "320c0492-de1d-4646-9e69-193d36b366e9",
-        "uuid": "320c0492-de1d-4646-9e69-193d36b366e9",
-        "name": "Biology",
-        "handle": "123456789/5285",
-        "metadata": [
-          {
-            "key": "dc.description.abstract",
-            "value": "",
-            "language": null
-          },
-          {
-            "key": "dc.title",
-            "value": "Biology",
-            "language": null
-          }
-        ],
-        "type": "collection",
-        "_links": {
-          "license": {
-            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/license"
-          },
-          "exportToZip": {
-            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/exportToZip"
-          },
-          "defaultAccessConditions": {
-            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/defaultAccessConditions"
-          },
-          "logo": {
-            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/logo"
-          },
-          "self": {
-            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9"
-          }
-        },
-        "_embedded": {
-          "logo": null,
-          "defaultAccessConditions": {
-            "_embedded": {
-              "defaultAccessConditions": [
-                {
-                  "id": 28050,
-                  "name": null,
-                  "groupUUID": "9e1794b8-45e0-4869-9c2c-36c4b25ce856",
-                  "action": "DEFAULT_BITSTREAM_READ",
-                  "type": "resourcePolicy",
-                  "_links": {
-                    "self": {
-                      "href": "https://dspace7.4science.it/dspace-spring-rest/api/authz/resourcePolicies/28050"
-                    }
-                  }
-                }
-              ]
-            },
-            "_links": {
-              "self": {
-                "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/defaultAccessConditions"
-              }
-            },
-            "page": {
-              "number": 0,
-              "size": 1,
-              "totalPages": 1,
-              "totalElements": 1
-            }
-          }
-        }
-      }
-    ]
-  }
-```
-
-It returns all the mapped collections the item is included in
+It returns all the mapped collections the item is included in.
 
 On the item page, it should be referenced similar to:
 ```json
@@ -420,37 +279,19 @@ Return codes:
 
 **PUT /api/core/items/<item:uuid>/mappedCollections**
 
-A PUT request will replace the list collections where an item is mapped with the list provided in the request.
+PUT is NOT SUPPORTED at this time. You may replace or update mapped collections using DELETE requests and/or POST requests.
 
-```
- curl -i -X PUT https://dspace7.4science.it/dspace-spring-rest/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections
- -H "Content-Type:text/uri-list" --data "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
-```
-
-For example, in the above request, the item with UUID 1911e8a4-6939-490c-b58b-a5d70f8d91fb will now only be mapped to the collection with UUID 1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb.
-Any previous mappings are removed/replaced.
-
-The collection(s) MUST be included in the body using the `text/uri-list` content type.
-
-Return codes:
- * 204: if the update succeeded (including the case of no-op if the mapping was already as requested)
- * 401 Forbidden - if you are not authenticated
- * 403 Unauthorized - if you are not logged in with sufficient permissions
- * 405: if the item is a template item
- * 422: if the specified collection is not found or is the owningCollection of the item
-
-**DELETE /api/core/items/<item:uuid>/mappedCollections**
+**DELETE /api/core/items/<item:uuid>/mappedCollections/<collection:uuid>**
 
 A DELETE request will result in removing an existing mapping between the item and collection
 If the collection exists and is a mapped collection for the item, the relation should be deleted
 
 ```
- curl -i -X DELETE https://dspace7.4science.it/dspace-spring-rest/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections 
- -H "Content-Type:text/uri-list" --data "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
- ```
+ curl -i -X DELETE https://dspace7.4science.it/dspace-spring-rest/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
+```
 
-The collection(s) MUST be included in the body using the `text/uri-list` content type.
- 
+The above request would remove the mapping between Collection with UUID `1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb` and Item with UUID `1911e8a4-6939-490c-b58b-a5d70f8d91fb`.
+
 Return codes:
  * 204: if the delete succeeded (including the case of no-op if the collection was not mapped) 
  * 401 Forbidden - if you are not authenticated

--- a/items.md
+++ b/items.md
@@ -245,6 +245,162 @@ Status codes:
 * 404 Not found - if the item doesn't exist
 * 422 Unprocessable Entity - if the collection doesn't exist or the data cannot be resolved to a collection
 
+### Mapping Collections
+**/api/core/items/<:uuid>/mappingCollections**
+
+Example:
+```json
+    "mappingCollections":
+    [
+      {
+        "id": "16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9",
+        "uuid": "16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9",
+        "name": "Bachelor theses",
+        "handle": "123456789/5287",
+        "metadata": [
+          {
+            "key": "dc.description.abstract",
+            "value": "",
+            "language": null
+          },
+          {
+            "key": "dc.title",
+            "value": "Bachelor theses",
+            "language": null
+          }
+        ],
+        "type": "collection",
+        "_links": {
+          "license": {
+            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/license"
+          },
+          "exportToZip": {
+            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/exportToZip"
+          },
+          "defaultAccessConditions": {
+            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/defaultAccessConditions"
+          },
+          "logo": {
+            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/logo"
+          },
+          "self": {
+            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9"
+          }
+        },
+        "_embedded": {
+          "logo": null,
+          "defaultAccessConditions": {
+            "_embedded": {
+              "defaultAccessConditions": [
+                {
+                  "id": 28054,
+                  "name": null,
+                  "groupUUID": "9e1794b8-45e0-4869-9c2c-36c4b25ce856",
+                  "action": "DEFAULT_BITSTREAM_READ",
+                  "type": "resourcePolicy",
+                  "_links": {
+                    "self": {
+                      "href": "https://dspace7-internal.atmire.com/rest/api/authz/resourcePolicies/28054"
+                    }
+                  }
+                }
+              ]
+            },
+            "_links": {
+              "self": {
+                "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/defaultAccessConditions"
+              }
+            },
+            "page": {
+              "number": 0,
+              "size": 1,
+              "totalPages": 1,
+              "totalElements": 1
+            }
+          }
+        }
+      },
+      {
+        "id": "320c0492-de1d-4646-9e69-193d36b366e9",
+        "uuid": "320c0492-de1d-4646-9e69-193d36b366e9",
+        "name": "Biology",
+        "handle": "123456789/5285",
+        "metadata": [
+          {
+            "key": "dc.description.abstract",
+            "value": "",
+            "language": null
+          },
+          {
+            "key": "dc.title",
+            "value": "Biology",
+            "language": null
+          }
+        ],
+        "type": "collection",
+        "_links": {
+          "license": {
+            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/license"
+          },
+          "exportToZip": {
+            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/exportToZip"
+          },
+          "defaultAccessConditions": {
+            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/defaultAccessConditions"
+          },
+          "logo": {
+            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/logo"
+          },
+          "self": {
+            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9"
+          }
+        },
+        "_embedded": {
+          "logo": null,
+          "defaultAccessConditions": {
+            "_embedded": {
+              "defaultAccessConditions": [
+                {
+                  "id": 28050,
+                  "name": null,
+                  "groupUUID": "9e1794b8-45e0-4869-9c2c-36c4b25ce856",
+                  "action": "DEFAULT_BITSTREAM_READ",
+                  "type": "resourcePolicy",
+                  "_links": {
+                    "self": {
+                      "href": "https://dspace7-internal.atmire.com/rest/api/authz/resourcePolicies/28050"
+                    }
+                  }
+                }
+              ]
+            },
+            "_links": {
+              "self": {
+                "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/defaultAccessConditions"
+              }
+            },
+            "page": {
+              "number": 0,
+              "size": 1,
+              "totalPages": 1,
+              "totalElements": 1
+            }
+          }
+        }
+      }
+    ]
+  }
+```
+
+It returns all the mapping collections the item is included in
+
+On the item page, it should be referenced similar to:
+```json
+    "mappingCollections": {
+      "href": "https://dspace7-internal.atmire.com/rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/mappingCollections"
+    }
+```
+
 ### Template Item
 **/api/core/items/<:uuid>/templateItemOf**
 

--- a/items.md
+++ b/items.md
@@ -399,15 +399,44 @@ On the item page, it should be referenced similar to:
     }
 ```
 
-**POST /api/core/items/<item:uuid>/mappedCollections?collection=<collection:uuid>**
+**POST /api/core/items/<item:uuid>/mappedCollections**
 
 A POST request will result in creating a new mapping between the item and collection
 If the collection exists and is neither the owning nor mapped collection for the item, the relation should be created
 
-**DELETE /api/core/items/<item:uuid>/mappedCollections?collection=<collection:uuid>**
+```
+ curl -i -X POST https://dspace7.4science.it/dspace-spring-rest/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections 
+ -H "Content-Type:text/uri-list" --data "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
+ ```
+
+The collection should be included in the body using a uri-list. It is mandatory
+ 
+Return codes:
+ * 204: if the update succeeded 
+ * 401 Forbidden - if you are not authenticated
+ * 403 Unauthorized - if you are not logged in with sufficient permissions 
+ * 405: if the item is a template item
+ * 422: if the specified collection is not found or is the owningCollection of the item
+
+**DELETE /api/core/items/<item:uuid>/mappedCollections**
 
 A DELETE request will result in removing an existing mapping between the item and collection
 If the collection exists and is a mapped collection for the item, the relation should be deleted
+
+```
+ curl -i -X DELETE https://dspace7.4science.it/dspace-spring-rest/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections 
+ -H "Content-Type:text/uri-list" --data "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
+ ```
+
+The collection should be included in the body using a uri-list. It is mandatory
+ 
+Return codes:
+ * 204: if the delete succeeded (including the case of no-op if the collection was not mapped) 
+ * 401 Forbidden - if you are not authenticated
+ * 403 Unauthorized - if you are not logged in with sufficient permissions 
+ * 405: if the item is a template item
+ * 422: if the specified collection is not found or is the owningCollection of the item
+
 
 ### Template Item
 **/api/core/items/<:uuid>/templateItemOf**

--- a/items.md
+++ b/items.md
@@ -273,16 +273,16 @@ Example:
         "type": "collection",
         "_links": {
           "license": {
-            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/license"
+            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/license"
           },
           "defaultAccessConditions": {
-            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/defaultAccessConditions"
+            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/defaultAccessConditions"
           },
           "logo": {
-            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/logo"
+            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/logo"
           },
           "self": {
-            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9"
+            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9"
           }
         },
         "_embedded": {
@@ -298,7 +298,7 @@ Example:
                   "type": "resourcePolicy",
                   "_links": {
                     "self": {
-                      "href": "https://dspace7-internal.atmire.com/rest/api/authz/resourcePolicies/28054"
+                      "href": "https://dspace7.4science.it/dspace-spring-rest/api/authz/resourcePolicies/28054"
                     }
                   }
                 }
@@ -306,7 +306,7 @@ Example:
             },
             "_links": {
               "self": {
-                "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/defaultAccessConditions"
+                "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/defaultAccessConditions"
               }
             },
             "page": {
@@ -338,19 +338,19 @@ Example:
         "type": "collection",
         "_links": {
           "license": {
-            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/license"
+            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/license"
           },
           "exportToZip": {
-            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/exportToZip"
+            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/exportToZip"
           },
           "defaultAccessConditions": {
-            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/defaultAccessConditions"
+            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/defaultAccessConditions"
           },
           "logo": {
-            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/logo"
+            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/logo"
           },
           "self": {
-            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9"
+            "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9"
           }
         },
         "_embedded": {
@@ -366,7 +366,7 @@ Example:
                   "type": "resourcePolicy",
                   "_links": {
                     "self": {
-                      "href": "https://dspace7-internal.atmire.com/rest/api/authz/resourcePolicies/28050"
+                      "href": "https://dspace7.4science.it/dspace-spring-rest/api/authz/resourcePolicies/28050"
                     }
                   }
                 }
@@ -374,7 +374,7 @@ Example:
             },
             "_links": {
               "self": {
-                "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/defaultAccessConditions"
+                "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/320c0492-de1d-4646-9e69-193d36b366e9/defaultAccessConditions"
               }
             },
             "page": {
@@ -395,7 +395,7 @@ It returns all the mapped collections the item is included in
 On the item page, it should be referenced similar to:
 ```json
     "mappedCollections": {
-      "href": "https://dspace7-internal.atmire.com/rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/mappedCollections"
+      "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/mappedCollections"
     }
 ```
 

--- a/items.md
+++ b/items.md
@@ -68,6 +68,7 @@ Provide detailed information about a specific item. The JSON response document i
 Exposed links:
 * bitstreams: list of bitstreams within the item
 * owningCollection: the collection where the item belong to
+* mappedCollections: the collections where the item is mapped to
 * templateItemOf: the collection that have the item as template
  
 ## Creating an archived item
@@ -245,12 +246,12 @@ Status codes:
 * 404 Not found - if the item doesn't exist
 * 422 Unprocessable Entity - if the collection doesn't exist or the data cannot be resolved to a collection
 
-### Mapping Collections
-**GET /api/core/items/<:uuid>/mappingCollections**
+### Mapped Collections
+**GET /api/core/items/<:uuid>/mappedCollections**
 
 Example:
 ```json
-    "mappingCollections":
+    "mappedCollections":
     [
       {
         "id": "16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9",
@@ -273,9 +274,6 @@ Example:
         "_links": {
           "license": {
             "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/license"
-          },
-          "exportToZip": {
-            "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/exportToZip"
           },
           "defaultAccessConditions": {
             "href": "https://dspace7-internal.atmire.com/rest/api/core/collections/16a4b65b-3b3f-4ef5-8058-ef6f5a653ef9/defaultAccessConditions"
@@ -392,24 +390,24 @@ Example:
   }
 ```
 
-It returns all the mapping collections the item is included in
+It returns all the mapped collections the item is included in
 
 On the item page, it should be referenced similar to:
 ```json
-    "mappingCollections": {
-      "href": "https://dspace7-internal.atmire.com/rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/mappingCollections"
+    "mappedCollections": {
+      "href": "https://dspace7-internal.atmire.com/rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/mappedCollections"
     }
 ```
 
-**POST /api/core/items/<item:uuid>/mappingCollections?collection=<collection:uuid>**
+**POST /api/core/items/<item:uuid>/mappedCollections?collection=<collection:uuid>**
 
 A POST request will result in creating a new mapping between the item and collection
-If the collection exists and is neither the owning nor mapping collection for the item, the relation should be created
+If the collection exists and is neither the owning nor mapped collection for the item, the relation should be created
 
-**DELETE /api/core/items/<item:uuid>/mappingCollections?collection=<collection:uuid>**
+**DELETE /api/core/items/<item:uuid>/mappedCollections?collection=<collection:uuid>**
 
 A DELETE request will result in removing an existing mapping between the item and collection
-If the collection exists and is a mapping collection for the item, the relation should be deleted
+If the collection exists and is a mapped collection for the item, the relation should be deleted
 
 ### Template Item
 **/api/core/items/<:uuid>/templateItemOf**

--- a/items.md
+++ b/items.md
@@ -247,7 +247,7 @@ Status codes:
 * 422 Unprocessable Entity - if the collection doesn't exist or the data cannot be resolved to a collection
 
 ### Mapped Collections
-**GET /api/core/items/<:uuid>/mappedCollections**
+**GET /api/core/items/<item:uuid>/mappedCollections**
 
 It returns all the mapped collections the item is included in.
 
@@ -257,6 +257,10 @@ On the item page, it should be referenced similar to:
       "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/mappedCollections"
     }
 ```
+
+**GET /api/core/items/<item:uuid>/mappedCollections/<collection:uuid>**
+
+Unsupported. If you want detailed information about a single mapped collection, use the `/api/core/collections/<collection:uuid>` endpoint.
 
 **POST /api/core/items/<item:uuid>/mappedCollections**
 

--- a/items.md
+++ b/items.md
@@ -247,7 +247,7 @@ Status codes:
 * 422 Unprocessable Entity - if the collection doesn't exist or the data cannot be resolved to a collection
 
 ### Mapped Collections
-**GET /api/core/items/<item:uuid>/mappedCollections**
+**GET /api/core/items/<:uuid>/mappedCollections**
 
 It returns all the mapped collections the item is included in.
 
@@ -258,11 +258,11 @@ On the item page, it should be referenced similar to:
     }
 ```
 
-**GET /api/core/items/<item:uuid>/mappedCollections/<collection:uuid>**
+**GET /api/core/items/<:uuid>/mappedCollections/<:collection_uuid>**
 
-Unsupported. If you want detailed information about a single mapped collection, use the `/api/core/collections/<collection:uuid>` endpoint.
+_Unsupported._ If you want detailed information about a single mapped collection, use the `/api/core/collections/<collection:uuid>` endpoint.
 
-**POST /api/core/items/<item:uuid>/mappedCollections**
+**POST /api/core/items/<:uuid>/mappedCollections**
 
 A POST request will result in creating a new mapping between the item and collection.
 If the collection exists and is neither the owning nor mapped collection for the item, the relation should be created.
@@ -281,11 +281,11 @@ Return codes:
  * 405: if the item is a template item
  * 422: if the specified collection is not found or is the owningCollection of the item
 
-**PUT /api/core/items/<item:uuid>/mappedCollections**
+**PUT /api/core/items/<:uuid>/mappedCollections**
 
 PUT is NOT SUPPORTED at this time. You may replace or update mapped collections using DELETE requests and/or POST requests.
 
-**DELETE /api/core/items/<item:uuid>/mappedCollections/<collection:uuid>**
+**DELETE /api/core/items/<:uuid>/mappedCollections/<:collection_uuid>**
 
 A DELETE request will result in removing an existing mapping between the item and collection
 If the collection exists and is a mapped collection for the item, the relation should be deleted

--- a/items.md
+++ b/items.md
@@ -401,20 +401,41 @@ On the item page, it should be referenced similar to:
 
 **POST /api/core/items/<item:uuid>/mappedCollections**
 
-A POST request will result in creating a new mapping between the item and collection
-If the collection exists and is neither the owning nor mapped collection for the item, the relation should be created
+A POST request will result in creating a new mapping between the item and collection.
+If the collection exists and is neither the owning nor mapped collection for the item, the relation should be created.
 
 ```
  curl -i -X POST https://dspace7.4science.it/dspace-spring-rest/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections 
  -H "Content-Type:text/uri-list" --data "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
- ```
+```
 
-The collection should be included in the body using a uri-list. It is mandatory
+The collection(s) MUST be included in the body using the `text/uri-list` content type
  
 Return codes:
- * 204: if the update succeeded 
+ * 204: if the update succeeded (including the case of no-op if the mapping was already as requested)
  * 401 Forbidden - if you are not authenticated
  * 403 Unauthorized - if you are not logged in with sufficient permissions 
+ * 405: if the item is a template item
+ * 422: if the specified collection is not found or is the owningCollection of the item
+
+**PUT /api/core/items/<item:uuid>/mappedCollections**
+
+A PUT request will replace the list collections where an item is mapped with the list provided in the request.
+
+```
+ curl -i -X PUT https://dspace7.4science.it/dspace-spring-rest/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections
+ -H "Content-Type:text/uri-list" --data "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
+```
+
+For example, in the above request, the item with UUID 1911e8a4-6939-490c-b58b-a5d70f8d91fb will now only be mapped to the collection with UUID 1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb.
+Any previous mappings are removed/replaced.
+
+The collection(s) MUST be included in the body using the `text/uri-list` content type.
+
+Return codes:
+ * 204: if the update succeeded (including the case of no-op if the mapping was already as requested)
+ * 401 Forbidden - if you are not authenticated
+ * 403 Unauthorized - if you are not logged in with sufficient permissions
  * 405: if the item is a template item
  * 422: if the specified collection is not found or is the owningCollection of the item
 
@@ -428,7 +449,7 @@ If the collection exists and is a mapped collection for the item, the relation s
  -H "Content-Type:text/uri-list" --data "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
  ```
 
-The collection should be included in the body using a uri-list. It is mandatory
+The collection(s) MUST be included in the body using the `text/uri-list` content type.
  
 Return codes:
  * 204: if the delete succeeded (including the case of no-op if the collection was not mapped) 
@@ -445,7 +466,7 @@ Example: to be provided
 
 It returns the collection that have the item as template
 
-## Deleting a collection
+## Deleting an item
 
 **DELETE /api/core/items/<:uuid>**
 


### PR DESCRIPTION
Replacement for #35 (@benbosman and @KevinVdV) and #44 (@abollini). 

This PR includes alterations to the items.md contract to add for mapping of items to collections.
JIRA: https://jira.duraspace.org/browse/DS-4097

I've attempted to bring in feedback from both prior PRs. Here's what I've done:
- [x] Started from #35 
- [x] Changed all "internal" atmire.com URLs to same base URL we use elsewhere. Yes, these links won't resolve, but that's fine.  Likely we should replace all URLs in the future, and we just want consistency for now
- [x] Added `PUT` definition from #44  (was missing from #35).

**BEFORE WE CAN MERGE THIS**
One outstanding question remains...we have a discrepancy on the `DELETE` method format:
* #35 expects DELETE to use "text/uri-list" (like PUT and POST)
* #44 expects DELETE to use `items/[:uuid]/mappedCollections/[:uuid_of_collection_to_remove]`

In the Spring Data REST community, they seem to recommend using `PUT` for deletion (by calling `PUT` with an empty body). See: https://stackoverflow.com/a/28713232/3750035  Though, there's also an answer more like #44 here: https://stackoverflow.com/a/40785090/3750035

For ease of parsing all these endpoints the same way, I wonder if we should simply use `PUT` for deletion.