### PR TITLE
DS-4107 Fix collection/community examples to use new metadata structure

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -157,16 +157,19 @@ see also the [ResourcePolicies endpoint](resourcepolicies.md)
 
 To create a collection, perform as post with the JSON below when logged in as admin.
 
-```
+```json
 {
-"name": "test collection",
-"metadata": [
-    {
-        "key": "dc.title",
+  "name": "test collection",
+  "metadata": {
+    "dc.title": [
+      {
         "value": "test collection",
-        "language": null
-    }
+        "language": null,
+        "authority": null,
+        "confidence": -1
+      }
     ]
+  }
 }
 ```
 
@@ -181,22 +184,29 @@ To create a collection, perform as post with the JSON below when logged in as ad
 **PUT /api/core/collections/<:uuid>**
 
 Provide updated metadata information about a specific collection, when the update is completed the updated object will be returned. The JSON to update can be found below.
-```
+
+```json
 {
-"uuid": "20263916-6a3d-4fdc-a44a-4616312f030c",
-"name": "test collection",
-"metadata": [
-    {
-        "key": "dc.title",
+  "uuid": "20263916-6a3d-4fdc-a44a-4616312f030c",
+  "name": "test collection",
+  "metadata": {
+    "dc.title": [
+      {
         "value": "test collection",
-        "language": null
-    },
-    {
-        "key": "dc.description",
+        "language": null,
+        "authority": null,
+        "confidence": -1
+      }
+    ],
+    "dc.description": [
+      {
         "value": "Test description",
-        "language": null
-    }
+        "language": null,
+        "authority": null,
+        "confidence": -1
+      }
     ]
+  }
 }
 ```  
 

--- a/communities.md
+++ b/communities.md
@@ -130,16 +130,19 @@ The supported parameters are:
 
 To create a top level community, perform as post with the JSON below to the communities endpoint when logged in as admin.
 
-```
+```json
 {
-    "name": "test creation",
-    "metadata": [
-        {
-            "key": "dc.title",
-            "value": "test creation",
-            "language": null
-        }
+  "name": "test creation",
+  "metadata": {
+    "dc.title": [
+      {
+        "value": "test creation",
+        "language": null,
+        "authority": null,
+        "confidence": -1
+      }
     ]
+  }
 }
 ```
 
@@ -149,16 +152,19 @@ To create a top level community, perform as post with the JSON below to the comm
 
 To create a sub level community, perform as post with the JSON below to the communities endpoint when logged in as admin.
 
-```
+```json
 {
-    "name": "test subcommunity",
-    "metadata": [
-        {
-            "key": "dc.title",
-            "value": "test subcommunity",
-            "language": null
-        }
+  "name": "test subcommunity",
+  "metadata": {
+    "dc.title": [
+      {
+        "value": "test subcommunity",
+        "language": null,
+        "authority": null,
+        "confidence": -1
+      }
     ]
+  }
 }
 ```
 
@@ -174,25 +180,31 @@ Error messages:
 
 Provide updated metadata information about a specific community, when the update is completed the updated object will be returned. The JSON to update can be found below.
 
-```
+```json
 {
-    "id": "b8872eba-1a79-4b8b-a8f6-55fa8f73197b",
-    "uuid": "b8872eba-1a79-4b8b-a8f6-55fa8f73197b",
-    "name": "test new title",
-    "handle": "123456789/60631",
-    "metadata": [
-        {
-            "key": "dc.title",
-            "value": "test new title",
-            "language": null
-        },
-        {
-            "key": "dc.description",
-            "value": "An example description",
-            "language": "en"
-        }
+  "id": "b8872eba-1a79-4b8b-a8f6-55fa8f73197b",
+  "uuid": "b8872eba-1a79-4b8b-a8f6-55fa8f73197b",
+  "name": "test new title",
+  "handle": "123456789/60631",
+  "metadata": {
+    "dc.title": [
+      {
+        "value": "test new title",
+        "language": null,
+        "authority": null,
+        "confidence": -1
+      }
     ],
-    "type": "community"
+    "dc.description": [
+      {
+        "value": "An example description",
+        "language": "en",
+        "authority": null,
+        "confidence": -1
+      }
+    ]
+  },
+  "type": "community"
 }
 ```  
 


### PR DESCRIPTION
DS-4107 contract changes were already approved in https://github.com/DSpace/Rest7Contract/pull/39

This new PR just cleans up some subsequently merged JSON that did not use the new, correct structure.