### PR TITLE
Configurable Entities - Item metadata place

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Returns whether the target resource is available.
 - `PUT`:
 Replaces the state of the target resource with the supplied request body. This updates the object (via full replacement). The updated information _must be included_ in the request body. An empty request body is not allowed, unless you are updating the object to be an empty object (with no attributes). Querystring parameters are not allowed, as `PUT` requests should always be performed on an existing object.
 
-- `PATCH`:
-Similar to PUT but partially updating the resources state. We adhere to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) see the [General rules for the Patch operation](patch.md) for more details.
+- `PATCH`
+Similar to PUT but partially updating the resources state. We adhere to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902).
+See [General rules for the Patch operation](patch.md) and [Modifying metadata via Patch](metadata-patch.md) for more details.
 
 - `DELETE`:
 Deletes the target resource (object).
@@ -98,7 +99,15 @@ Only supported for collection associations (i.e. associations allowing for multi
    ```
 
 - `DELETE`:
-Unbinds (unlinks) the association. Return `405 Method Not Allowed` if the association is required (and cannot be removed)
+Unbinds (unlinks) the association. Return `405 Method Not Allowed` if the association is required (and cannot be removed).  DELETE requests should _not_ contain a request body as some clients do not support sending a DELETE request with a body. Therefore, if an individual association needs to be removed, the DELETE request should reference that individual association in the URI of the request. For example:
+   ```
+   # Example curl command to delete a *single* Collection mapping for an Item
+   curl -i -X DELETE "http://localhost:8080/rest/api/core/items/<:uuid>/mappedCollections/<:collection_uuid>"
+   
+   # Example curl command to delete *ALL* Collection mappings for an item (unsupported at this time)
+   curl -i -X DELETE "http://localhost:8080/rest/api/core/items/<:uuid>/mappedCollections
+   ```
+
 
 ### Error codes
 400 Bad Request - if multiple URIs were given for a to-one-association

--- a/bitstreams.md
+++ b/bitstreams.md
@@ -33,6 +33,10 @@ Exposed links:
 * format: link to the bitstream format resource associated with the bitstream (Adobe PDF, MS Word, etc.)
 * content: link to access the actual content of the bitstream
 
+## Patch operations
+
+Bitstream metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).
+
 ## Linked entities
 ### Format
 **/api/core/bitstreams/<:uuid>/format**

--- a/collections.md
+++ b/collections.md
@@ -90,6 +90,10 @@ Exposed links:
 * license: link to the license template used by the collection
 * defaultAccessConditions: link to the resource policies applied by default to new submissions in the collection
 
+## Patch operations
+
+Collection metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).
+
 ## Linked entities
 ### Logo
 **/api/core/collections/<:uuid>/logo**
@@ -157,16 +161,19 @@ see also the [ResourcePolicies endpoint](resourcepolicies.md)
 
 To create a collection, perform as post with the JSON below when logged in as admin.
 
-```
+```json
 {
-"name": "test collection",
-"metadata": [
-    {
-        "key": "dc.title",
+  "name": "test collection",
+  "metadata": {
+    "dc.title": [
+      {
         "value": "test collection",
-        "language": null
-    }
+        "language": null,
+        "authority": null,
+        "confidence": -1
+      }
     ]
+  }
 }
 ```
 
@@ -181,22 +188,29 @@ To create a collection, perform as post with the JSON below when logged in as ad
 **PUT /api/core/collections/<:uuid>**
 
 Provide updated metadata information about a specific collection, when the update is completed the updated object will be returned. The JSON to update can be found below.
-```
+
+```json
 {
-"uuid": "20263916-6a3d-4fdc-a44a-4616312f030c",
-"name": "test collection",
-"metadata": [
-    {
-        "key": "dc.title",
+  "uuid": "20263916-6a3d-4fdc-a44a-4616312f030c",
+  "name": "test collection",
+  "metadata": {
+    "dc.title": [
+      {
         "value": "test collection",
-        "language": null
-    },
-    {
-        "key": "dc.description",
+        "language": null,
+        "authority": null,
+        "confidence": -1
+      }
+    ],
+    "dc.description": [
+      {
         "value": "Test description",
-        "language": null
-    }
+        "language": null,
+        "authority": null,
+        "confidence": -1
+      }
     ]
+  }
 }
 ```  
 

--- a/communities.md
+++ b/communities.md
@@ -130,16 +130,19 @@ The supported parameters are:
 
 To create a top level community, perform as post with the JSON below to the communities endpoint when logged in as admin.
 
-```
+```json
 {
-    "name": "test creation",
-    "metadata": [
-        {
-            "key": "dc.title",
-            "value": "test creation",
-            "language": null
-        }
+  "name": "test creation",
+  "metadata": {
+    "dc.title": [
+      {
+        "value": "test creation",
+        "language": null,
+        "authority": null,
+        "confidence": -1
+      }
     ]
+  }
 }
 ```
 
@@ -149,16 +152,19 @@ To create a top level community, perform as post with the JSON below to the comm
 
 To create a sub level community, perform as post with the JSON below to the communities endpoint when logged in as admin.
 
-```
+```json
 {
-    "name": "test subcommunity",
-    "metadata": [
-        {
-            "key": "dc.title",
-            "value": "test subcommunity",
-            "language": null
-        }
+  "name": "test subcommunity",
+  "metadata": {
+    "dc.title": [
+      {
+        "value": "test subcommunity",
+        "language": null,
+        "authority": null,
+        "confidence": -1
+      }
     ]
+  }
 }
 ```
 
@@ -174,25 +180,31 @@ Error messages:
 
 Provide updated metadata information about a specific community, when the update is completed the updated object will be returned. The JSON to update can be found below.
 
-```
+```json
 {
-    "id": "b8872eba-1a79-4b8b-a8f6-55fa8f73197b",
-    "uuid": "b8872eba-1a79-4b8b-a8f6-55fa8f73197b",
-    "name": "test new title",
-    "handle": "123456789/60631",
-    "metadata": [
-        {
-            "key": "dc.title",
-            "value": "test new title",
-            "language": null
-        },
-        {
-            "key": "dc.description",
-            "value": "An example description",
-            "language": "en"
-        }
+  "id": "b8872eba-1a79-4b8b-a8f6-55fa8f73197b",
+  "uuid": "b8872eba-1a79-4b8b-a8f6-55fa8f73197b",
+  "name": "test new title",
+  "handle": "123456789/60631",
+  "metadata": {
+    "dc.title": [
+      {
+        "value": "test new title",
+        "language": null,
+        "authority": null,
+        "confidence": -1
+      }
     ],
-    "type": "community"
+    "dc.description": [
+      {
+        "value": "An example description",
+        "language": "en",
+        "authority": null,
+        "confidence": -1
+      }
+    ]
+  },
+  "type": "community"
 }
 ```  
 
@@ -213,3 +225,7 @@ Delete a community.
 * 401 Forbidden - if you are not authenticated
 * 403 Unauthorized - if you are not logged in with sufficient permissions
 * 404 Not found - if the community doesn't exist (or was already deleted)
+
+## Patch operations
+
+Community metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).

--- a/epersons.md
+++ b/epersons.md
@@ -9,11 +9,16 @@
 
 ## Patch operations
 
+EPerson metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).
+
+Additional properties can be modified via Patch as described below.
+
 ### Replace
 The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation to set not yet initialized information must return an error. See [general errors on PATCH requests](patch.md)
 
+#### These operations can be performed by administrators.
 
-To replace the certificate required value, `curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/certificate", "value": "true|false"]'`.  The operation also requires an Authorization header.
+To replace the certificate required value, `curl -X PATCH http://${dspace.url}/api/eperson/epersons/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/certificate", "value": "true|false"]'`.  The operation also requires an Authorization header.
 
 For example, starting with the following eperson field data:
 ```json
@@ -24,7 +29,7 @@ the replace operation `[{ "op": "replace", "path": "/certificate", "value": "fal
   "requireCerticate": false,
 ```
 
-To replace the canLogin value, `curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/canLogin", "value": "true|false"]'`.  The operation also requires an Authorization header.
+To replace the canLogin value, `curl -X PATCH http://${dspace.url}/api/eperson/epersons/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/canLogin", "value": "true|false"]'`.  The operation also requires an Authorization header.
 
 For example, starting with the following eperson field data:
 ```json
@@ -34,7 +39,7 @@ the replace operation `[{ "op": "replace", "path": "/canLogin", "value": "false"
 ```json
   "canLogIn": false,
 ```
-To replace the netid value, `curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/netid", "value": "newNetId"]'`.  The operation also requires an Authorization header.
+To replace the netid value, `curl -X PATCH http://${dspace.url}/api/eperson/epersons/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/netid", "value": "newNetId"]'`.  The operation also requires an Authorization header.
 
 For example, starting with the following eperson field data:
 ```json
@@ -45,7 +50,20 @@ the replace operation `[{ "op": "replace", "path": "/netid", "value": "newNetId"
   "netid": "newNetId",
 ```
 
-To replace the password value, `curl -X PATCH http://${dspace.url}/api/epersons/eperson/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/password", "value": "newpassword"]'`.  The operation also requires an Authorization header.
+To replace the email value, `curl -X PATCH http://${dspace.url}/api/eperson/epersons/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/email", "value": "new@email"]'`.  The operation also requires an Authorization header.
+
+For example, starting with the following eperson field data:
+```json
+ "email": "old@email",
+```
+the replace operation `[{ "op": "replace", "path": "/email", "value": "new@email"]` will result in :
+```json
+  "email": "new@email",
+  ```
+  
+#### This operation can be performed by administrators and by the authenticated user.
+
+To replace the password value, `curl -X PATCH http://${dspace.url}/api/eperson/epersons/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/password", "value": "newpassword"]'`.  The operation also requires an Authorization header.
 
 For example, starting with the following eperson field data:
 ```json
@@ -55,4 +73,4 @@ the replace operation `[{ "op": "replace", "path": "/password", "value": "newpas
 ```json
   "password": "newpassword",
 ```
-Note: The new password is currently returned after an update but this could be revisited later, see [#30]((https://github.com/DSpace/Rest7Contract/issues/30))
+NOTE: The new password is currently returned after an update but this could be revisited later, see [#30]((https://github.com/DSpace/Rest7Contract/issues/30))

--- a/items.md
+++ b/items.md
@@ -23,21 +23,24 @@ Provide detailed information about a specific item. The JSON response document i
         "value": "Stvilia, Besiki",
         "language": "en",
         "authority": null,
-        "confidence": -1
+        "confidence": -1,
+        "place": 0
       },
       {
         "value": "Lee, Dong Joon",
         "language": "en",
         "authority": null,
-        "confidence": -1
-      },
+        "confidence": -1,
+        "place": 1
+      }
     ],
     "dc.identifier.url": [
       {
         "value": "http://europepmc.org/abstract/MED/28301533",
         "language": "en",
         "authority": null,
-        "confidence": -1
+        "confidence": -1,
+        "place": 0
       }
     ],
     "dc.title": [
@@ -45,7 +48,8 @@ Provide detailed information about a specific item. The JSON response document i
         "value": "Practices of research data curation in institutional repositories: A qualitative view from repository staff",
         "language": "en",
         "authority": null,
-        "confidence": -1
+        "confidence": -1,
+        "place": 0
       }
     ],
     "dc.type": [
@@ -53,7 +57,8 @@ Provide detailed information about a specific item. The JSON response document i
         "value": "Journal Article",
         "language": "en",
         "authority": null,
-        "confidence": -1
+        "confidence": -1,
+        "place": 0
       }
     ]
   },
@@ -77,7 +82,7 @@ Exposed links:
 
 Administrators can directly create an archived item (bypassing the workflow). An example JSON can be seen below:
 
-```
+```json
 {
   "name": "Practices of research data curation in institutional repositories: A qualitative view from repository staff",
   "metadata": {
@@ -119,7 +124,7 @@ Administrators can directly create an archived item (bypassing the workflow). An
 
 Provide updated metadata information for an item, when the update is completed the updated object will be returned. The JSON to update can be found below.
 
-```
+```json
 {
   "id": "a8ba963f-d9c9-4198-b5a4-3f74e2ab6fb9",
   "uuid": "a8ba963f-d9c9-4198-b5a4-3f74e2ab6fb9",

--- a/items.md
+++ b/items.md
@@ -68,6 +68,7 @@ Provide detailed information about a specific item. The JSON response document i
 Exposed links:
 * bitstreams: list of bitstreams within the item
 * owningCollection: the collection where the item belong to
+* mappedCollections: the collections where the item is mapped to
 * templateItemOf: the collection that have the item as template
  
 ## Creating an archived item
@@ -151,10 +152,14 @@ Provide updated metadata information for an item, when the update is completed t
  
 ## Patch operations
 
+Item metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).
+
+Additional properties can be modified via Patch as described below.
+
 ### Replace
 The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation to set not yet initialized information must return an error. See [general errors on PATCH requests](patch.md)
 
-To withdraw an item, `curl --data '{[ { "op": "replace", "path": "/withdrawn", "value": true}]}' -X PATCH ${dspace7-url}/api/core/items/${item-uuid}`.  The withdraw operation also requires an Authorization header.
+To withdraw an item, `curl --data '[ { "op": "replace", "path": "/withdrawn", "value": true}]' -H "Authorization: Bearer ..." -H "content-type: application/json" -X PATCH ${dspace7-url}/api/core/items/${item-uuid}`.  The withdraw operation also requires an Authorization header.
 
 For example, starting with the following item data:
 ```json
@@ -173,7 +178,7 @@ the withdraw operation will result in:
   "type": "item"
 ```
 
-To reinstate an item, `curl --data '{[ { "op": "replace", "path": "/withdrawn", "value": false}]}' -X PATCH ${dspace7-url}/api/core/items/${item-uuid}`.  The reinstate operation also requires an Authorization header.
+To reinstate an item, `curl --data '[ { "op": "replace", "path": "/withdrawn", "value": false}]' -H "Authorization: Bearer ..." -H "content-type: application/json" -X PATCH ${dspace7-url}/api/core/items/${item-uuid}`.  The reinstate operation also requires an Authorization header.
 
 For example, starting with the following item data:
 ```json
@@ -245,6 +250,68 @@ Status codes:
 * 404 Not found - if the item doesn't exist
 * 422 Unprocessable Entity - if the collection doesn't exist or the data cannot be resolved to a collection
 
+### Mapped Collections
+**GET /api/core/items/<:uuid>/mappedCollections**
+
+It returns all the mapped collections the item is included in.
+
+On the item page, it should be referenced similar to:
+```json
+    "mappedCollections": {
+      "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/items/95e5d7d9-ef4e-4e35-86cc-07bfe2f0e355/mappedCollections"
+    }
+```
+
+**GET /api/core/items/<:uuid>/mappedCollections/<:collection_uuid>**
+
+_Unsupported._ If you want detailed information about a single mapped collection, use the `/api/core/collections/<collection:uuid>` endpoint.
+
+**POST /api/core/items/<:uuid>/mappedCollections**
+
+A POST request will result in creating a new mapping between the item and collection.
+If the collection exists and is neither the owning nor mapped collection for the item, the relation should be created.
+
+```
+ curl -i -X POST https://dspace7.4science.it/dspace-spring-rest/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections 
+ -H "Content-Type:text/uri-list" --data "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
+```
+
+The collection(s) MUST be included in the body using the `text/uri-list` content type
+ 
+Return codes:
+ * 204: if the update succeeded (including the case of no-op if the mapping was already as requested)
+ * 401 Forbidden - if you are not authenticated
+ * 403 Unauthorized - if you are not logged in with sufficient permissions 
+ * 405: if the item is a template item
+ * 422: if the specified collection is not found or is the owningCollection of the item
+
+**PUT /api/core/items/<:uuid>/mappedCollections**
+
+_Unsupported._ You may replace or update mapped collections using DELETE requests and/or POST requests.
+
+**DELETE /api/core/items/<:uuid>/mappedCollections**
+
+_Unsupported._ At this time, we do not support removing all mapped Collections in a single request. Please use `DELETE /api/core/items/<:uuid>/mappedCollections/<:collection_uuid>` to remove mapped Collections one by one.
+
+**DELETE /api/core/items/<:uuid>/mappedCollections/<:collection_uuid>**
+
+A DELETE request will result in removing an existing mapping between the item and collection.
+If the collection exists and is a mapped collection for the item, the relation should be deleted.
+
+```
+ curl -i -X DELETE https://dspace7.4science.it/dspace-spring-rest/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb/mappedCollections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb"
+```
+
+The above request would remove the mapping between Collection with UUID `1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb` and Item with UUID `1911e8a4-6939-490c-b58b-a5d70f8d91fb`.
+
+Return codes:
+ * 204: if the delete succeeded (including the case of no-op if the collection was not mapped) 
+ * 401 Forbidden - if you are not authenticated
+ * 403 Unauthorized - if you are not logged in with sufficient permissions 
+ * 405: if the item is a template item
+ * 422: if the specified collection is not found or is the owningCollection of the item
+
+
 ### Template Item
 **/api/core/items/<:uuid>/templateItemOf**
 
@@ -259,7 +326,7 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
 
 It embeds all relationships where either the left or the right item matches the given uuid
 
-## Deleting a collection
+## Deleting an item
 
 **DELETE /api/core/items/<:uuid>**
 

--- a/metadata-patch.md
+++ b/metadata-patch.md
@@ -1,0 +1,205 @@
+# Modifying metadata via Patch
+[Back to the index](README.md)
+
+**Contents:**
+
+* [Introduction](#introduction)
+* [Adding metadata](#adding-metadata)
+* [Removing metadata](#removing-metadata)
+* [Replacing metadata](#replacing-metadata)
+* [Ordering metadata](#ordering-metadata)
+
+## Introduction
+
+A user with write permission on a DSpace object may change any of its metadata
+using an HTTP PATCH request. All DSpace object types (Bitstreams, Items, Collections, etc.)
+support metadata changes in roughly the same way.
+
+This guide is focused on metadata-only changes and omits non-metadata parts of the object's
+json representation for brevity. However, you should be aware that PATCH requests operate
+against the whole object, and may therefore modify other mutable attributes in the same
+request.
+
+For additional information about PATCH support in DSpace, including request format and response
+status code details, see [General rules for the Patch operation](patch.md)
+
+The examples in each section below build on each other, assuming an initial metadata state of:
+
+```json
+{
+  "metadata": {
+    "dc.title": [
+      { "value": "Initial Title", "language": null, "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```
+
+Note: The metadata of items _in submission_ is modeled in the same way described here -- as a map
+of metadata keys to an ordered array of values. The primary difference is where the metadata
+is located within the JSON representation. The documentation and examples below apply to archived
+items and other DSpace object types, whereas the [WorkspaceItem Metadata](workspaceitem-data-metadata.md)
+document describes how item metadata can be modified during submission.
+
+## Adding metadata
+
+With the `add` operation, you can add any number of metadata values in a single request.
+
+You also use `add` to effectively _replace_ all values for a given metadata key, by specifying
+an already-present key as the `path`, and an array of your replacement values as the `value`.
+This use of the add operation to replace a list of values may be counter-intiutive, but it
+is done according to the [RFC section 4.1](https://tools.ietf.org/html/rfc6902#section-4.1)
+
+> If the target location specifies an object member that does exist, that member's value is replaced.
+
+Note:
+
+* According to the [JSON Patch specification](https://tools.ietf.org/html/rfc6902), to initialize the first
+  value for any array, the `add` operation must receive an array of values. Therefore, in the first operation
+  below, since it is not possible to add a single value to the not yet initialized `/metadata/dc.description`
+  array, we initialize it with an array with one value.
+* When values already exist for a metadata key, as in the second operation below, it is necessary to specify
+  the new value's position at the end of the `path` (`/0` means first position, `/-` means last).
+* When creating new metadata values, if unspecified, the `language` and `authority` properties
+  default to `null`, and `confidence` defaults to `-1`.
+
+Example request, adding three values:
+
+```json
+[
+  {
+    "op": "add",
+    "path": "/metadata/dc.description",
+    "value": [ { "value": "Some description" } ]
+  },
+  {
+    "op": "add",
+    "path": "/metadata/dc.title/0",
+    "value": { "value": "Zeroth Title" }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/dc.title/-",
+    "value": { "value": "Final Title", "language": "en_US" }
+  }
+]
+```
+
+New metadata state:
+
+```json
+{
+  "metadata": {
+    "dc.description": [
+      { "value": "Some description", "language": null, "authority": null, "confidence": -1 }
+    ],
+    "dc.title": [
+      { "value": "Zeroth Title", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Initial Title", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Final Title", "language": "en_US", "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```
+
+## Removing metadata
+
+With the `remove` operation, you can delete:
+
+* All metadata with a given key (e.g. `path="/metadata/dc.description"`)
+* A single metadata value with a known position (e.g. `path="/metadata/dc.title/0"`)
+
+When only one value is present for a particular key, it is functionally equivalent to
+specify the path to the key or the value.
+
+Example request, removing two values:
+
+```json
+[
+  {
+    "op": "remove",
+    "path": "/metadata/dc.description"
+  },
+  {
+    "op": "remove",
+    "path": "/metadata/dc.title/0"
+  }
+]
+```
+
+New metadata state:
+
+```json
+{
+  "metadata": {
+    "dc.title": [
+      { "value": "Initial Title", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Final Title", "language": "en_US", "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```
+
+## Replacing metadata
+
+With `replace`, you can overwrite any of the following within a single operation
+of a PATCH request:
+
+* The entire set of all object metadata (`path="/metadata"`)
+* All metadata values for an existing key (e.g. `path="/metadata/dc.title"`)
+* A single existing metadata value (e.g. `path="/metadata/dc.title/0"`)
+* A single property of an existing value (e.g. `path="/metadata/dc.title/0/language"`)
+
+Example request, replacing the `value` and `language` of the first `dc.title`:
+
+```json
+[
+  {
+    "op": "replace",
+    "path": "/metadata/dc.title/0",
+    "value": { "value": "最後のタイトル", "language": "ja_JP" }
+  }
+]
+```
+
+New metadata state:
+
+```json
+{
+  "metadata": {
+    "dc.title": [
+      { "value": "最後のタイトル", "language": "ja_JP", "authority": null, "confidence": -1 },
+      { "value": "Final Title", "language": "en_US", "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```
+
+## Ordering metadata
+
+Metadata may be re-ordered with the `move` operation.
+
+Example request, moving the last `dc.title` value to the first position:
+
+```json
+[
+  {
+    "op": "move",
+    "from": "/metadata/dc.title/1",
+    "path": "/metadata/dc.title/0"
+  }
+]
+```
+
+New metadata state:
+
+```json
+{
+  "metadata": {
+    "dc.title": [
+      { "value": "Final Title", "language": "en_US", "authority": null, "confidence": -1 },
+      { "value": "最後のタイトル", "language": "ja_JP", "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```

--- a/search-rels.md
+++ b/search-rels.md
@@ -1,14 +1,19 @@
-# Endpoint' Search methods
+# Search methods on collection endpoints
 [REST Overview Documentation](README.md)
 
-Resources collection should expose search methods to return specific subsets depending on the user requirements. Such as the items from a specific submitter, the top level communities, etc.
-All these methods should be exposed under <resources-collection-endpoint>/search/<method-name> at <resources-collection-endpoint>/search a HAL document should list all the available search methods for the resources collection
+Individual collection endpoints (e.g. `/api/core/{model}`) may expose search methods (`/api/core/{model}/search`) to return specific subsets of resources. This allows for filtering of the collection (group of resources) to only return specific resources that match the search requirements. Some examples include a search endpoint for only returning top-level Communities (e.g. `/api/core/communities/search/top`) or a search endpoint for only returning WorkspaceItems from a specific Submitter (e.g. `/api/submission/workspaceitems/search/findBySubmitter?uuid=<:submitter-uuid>`).
+
+Search endpoints on a collection of resources should act as follows:
+* All available search methods (for the given resource) should be exposed under `/api/core/{model}/search`. The result should be a HAL document.
+* Individual search methods should be exposed under `/api/core/{model}/search/{method-name}`
 
 **Please note that the [Discovery search](search-endpoint.md) is a completely separate topic**
 
-## Endpoint that have Search methods
-* /core/communities
-* /config/submissiondefinitions
-
-## Under Development
-* /submission/workspaceitems
+## Endpoints that have Search methods
+* [/api/core/communities](communities.md)
+* [/api/core/metadatafields/](metadatafields.md)
+* [/api/config/submissiondefinitions](submissiondefinitions.md)
+* [/api/submission/workspaceitems](workspaceitems.md)
+* [/api/workflow/claimedtasks](claimedtasks.md)
+* [/api/workflow/polltasks](polltasks.md)
+* [/api/workflow/workflowitems](workflowitems.md)

--- a/workspaceitem-data-metadata.md
+++ b/workspaceitem-data-metadata.md
@@ -1,36 +1,36 @@
 # WorkspaceItem data of submission-form sectionType
 [Back to the definition of the workspaceitems endpoint](workspaceitems.md)
 
-The section data represent the metadata collected for a specific [submissionform](submissionforms.md) it is a json object with the following structure
+The section data represent the metadata collected for a specific [submissionform](submissionforms.md).
+It is a json object with the following structure:
 
 ```json
-      "dc.contributor.author": [
-        {
-          "value": "Bollini, Andrea",
-          "language": null,
-          "authority": "rp00001",
-          "confidence": 600,
-          "place": 0
-        }
-      ],
-      "dc.title": [
-        {
-          "value": "Sample Submission Item",
-          "language": "en_US",
-          "authority": null,
-          "confidence": -1,
-          "place": 0
-        }
-      ],
-      "dc.date.issued": [
-        {
-          "value": "test",
-          "language": null,
-          "authority": null,
-          "confidence": -1,
-          "place": 0
-        }
-      ]   
+{
+  "dc.contributor.author": [
+    {
+      "value": "Bollini, Andrea",
+      "language": null,
+      "authority": "rp00001",
+      "confidence": 600
+    }
+  ],
+  "dc.title": [
+    {
+      "value": "Sample Submission Item",
+      "language": "en_US",
+      "authority": null,
+      "confidence": -1
+    }
+  ],
+  "dc.date.issued": [
+    {
+      "value": "test",
+      "language": null,
+      "authority": null,
+      "confidence": -1
+    }
+  ]   
+}
 ```
 
 The attribute name is the metadata key using the '.' dot separator (i.e. dc.title, dc.contributor.author, etc.) the value is an array, sorted by the metadatavalue.place column, containing
@@ -38,6 +38,12 @@ The attribute name is the metadata key using the '.' dot separator (i.e. dc.titl
 * authority: the authority key if any associated
 * confidence: the level of confidence for the authority if any, -1 otherwise
 * language: the iso code associated with the textual value if any
+
+Note: The metadata of _archived_ items is modeled in the same way described here -- as a map
+of metadata keys to an ordered array of values. The primary difference is where the metadata
+is located within the JSON representation. The documentation and examples below apply to
+items during submission, whereas the [Modifying Metadata via PATCH](metadata-patch.md)
+document describes how they can be modified _after_ they have been archived.
 
 ## Patch operations
 The PATCH method expects a JSON body according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902)


### PR DESCRIPTION
This is a Pull Request in the configurable entities branch

The item metadata wasn't revealing the place column yet in https://github.com/DSpace/Rest7Contract/pull/39

This was however present in configurable entities as part of https://github.com/DSpace/DSpace/pull/2331:
```json
{
  "metadata": [
    {
      "key": "dc.contributor.author",
      "value": "Simmons, Cameron",
      "language": "*",
      "place": 0,
      "authority": "virtual::732",
      "confidence": -1
    },
    {
      "key": "dc.contributor.author",
      "value": "Plain text author",
      "language": null,
      "place": 1,
      "authority": null,
      "confidence": -1
    },
    {
      "key": "dc.contributor.author",
      "value": "Plain text author 2",
      "language": null,
      "place": 2,
      "authority": null,
      "confidence": -1
    },
    {
      "key": "relation.isAuthorOfPublication",
      "value": "0ffbee3f-e7ea-42bc-92fe-2fbef1a52c0f",
      "language": "*",
      "place": 1,
      "authority": "virtual::889",
      "confidence": -1
    },
    {
      "key": "dc.contributor.author",
      "value": "Van de Velde, Kevin",
      "language": "*",
      "place": 4,
      "authority": "virtual::890",
      "confidence": -1
    }
  ]
}
```

This place column is not really important for plain text metadata, but it is important for configurable entities. For the sample use case of authors in a publication, it is needed:
* For rendering e.g. the ordered mixture of plain text and entity authors
* For edits to the order between the authors

After a brief talk with Chris, this has been included in 
https://github.com/DSpace/Rest7Contract/commit/019672a7ecdd7a656e054bcc5ffb71ae3ae29ef0

The remainder of this PR is just bringing configurable_entities up-to-date with master because this commit required the latest items.md