### PR TITLE
support for defining relationship lookups in the submission forms

### DIFF
--- a/submissionforms.md
+++ b/submissionforms.md
@@ -138,6 +138,57 @@ Provide detailed information about a specific input-form. The JSON response docu
           "languageCodes": []
         }
       ]
+    },
+    {
+      "fields": [
+        {
+          "input": {
+            "relationship": true
+          },
+          "label": "Journal",
+          "mandatory": false,
+          "repeatable": false,
+          "hints": "Select the journal related to this volume.",
+          "selectableRelationship": [
+            {
+              "relationship": "isVolumeOfJournal",
+              "filter": "creativework.publisher:somepublishername",
+              "search-configuration": "periodicalConfiguration"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "fields": [
+        {
+          "input": {
+            "type": "name",
+            "relationship": true
+          },
+          "label": "Author",
+          "mandatory": true,
+          "repeatable": true,
+          "mandatoryMessage": "At least one author (plain text or relationship) is required",
+          "hints": "Add an author",
+          "selectableRelationship": [
+            {
+              "relationship": "isAuthorOfPublication",
+              "filter": null,
+              "search-configuration": "personConfiguration"
+            }
+          ],
+          "selectableMetadata": [
+            {
+              "metadata": "dc.contributor.author",
+              "label": null,
+              "authority": null,
+              "closed": false
+            }
+          ],
+          "languageCodes": []
+        }
+      ]
     }
   ],
   "type": "submissionform"

--- a/submissionforms.md
+++ b/submissionforms.md
@@ -142,9 +142,7 @@ Provide detailed information about a specific input-form. The JSON response docu
     {
       "fields": [
         {
-          "input": {
-            "relationship": true
-          },
+          "input": { },
           "label": "Journal",
           "mandatory": false,
           "repeatable": false,
@@ -163,8 +161,7 @@ Provide detailed information about a specific input-form. The JSON response docu
       "fields": [
         {
           "input": {
-            "type": "name",
-            "relationship": true
+            "type": "name"
           },
           "label": "Author",
           "mandatory": true,


### PR DESCRIPTION
Example of a closed and open relationship in the submission forms
This has been discussed in the entities meeting, and is documented at https://docs.google.com/document/d/1X0XsppZYOtPtbmq7yXwmu7FbMAfLxxOCONbw0_rl7jY/edit#heading=h.5bu9shx0j942 and https://docs.google.com/document/d/1X0XsppZYOtPtbmq7yXwmu7FbMAfLxxOCONbw0_rl7jY/edit#heading=h.yf95g3tikk1j