### PR TITLE
OAI Harvesting configuration

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -155,6 +155,129 @@ The json representation is as follow
 ```
 see also the [ResourcePolicies endpoint](resourcepolicies.md)
 
+### Collection Harvesting Settings
+**GET /api/core/collections/<:uuid>/harvestingSettings**
+
+It returns the harvesting settings for the current collection. This information is only accessible for users with collection administration permissions
+
+A sample json response:
+
+```json
+{
+  "harvest_type": "METADATA_ONLY",
+  "oai_source": "https://dspace.mit.edu/oai/request",
+  "oai_set_id": "col_1721.1_114174",
+  "harvest_message": null,
+  "metadata_config_id": "dc",
+  "harvest_status": "ready",
+  "harvest_start_time": null,
+  "last_harvested": null,
+  "_links": {
+    "self": {
+      "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/6f944500-c300-449a-9023-a5ad8bd21160/harvestingSettings"
+    }
+  },
+  "_embedded": {
+    "metadata_configs": {
+      "configs": [
+        {
+           "id": "dc",
+           "label": "Simple Dublin Core",
+           "nameSpace": "http://www.openarchives.org/OAI/2.0/oai_dc/"
+        },
+        {
+           "id": "qdc",
+           "label": "Qualified Dublin Core",
+           "nameSpace": "http://purl.org/dc/terms/"
+        },
+        {
+           "id": "dim",
+           "label": "DSpace Intermediate Metadata",
+           "nameSpace": "http://www.dspace.org/xmlns/dspace/dim"
+        }
+      ],
+      "_links": {
+        "self": {
+          "href": "https://dspace7.4science.it/dspace-spring-rest/api/config/harvesting_metadata_configs"
+        }
+      }
+    }
+    
+  }
+}
+```
+
+A sample json response if no harvesting is enabled:
+
+```json
+{
+  "harvest_type": "NONE",
+  "oai_source": null,
+  "oai_set_id": null,
+  "harvest_message": null,
+  "metadata_config_id": null,
+  "harvest_status": null,
+  "harvest_start_time": null,
+  "last_harvested": null,
+  "_links": {
+    "self": {
+      "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/6f944500-c300-449a-9023-a5ad8bd21160/harvestingSettings"
+    }
+  },
+  "_embedded": {
+    "metadata_configs": {
+      "configs": [
+        {
+           "id": "dc",
+           "label": "Simple Dublin Core",
+           "nameSpace": "http://www.openarchives.org/OAI/2.0/oai_dc/"
+        },
+        {
+           "id": "qdc",
+           "label": "Qualified Dublin Core",
+           "nameSpace": "http://purl.org/dc/terms/"
+        },
+        {
+           "id": "dim",
+           "label": "DSpace Intermediate Metadata",
+           "nameSpace": "http://www.dspace.org/xmlns/dspace/dim"
+        }
+      ],
+      "_links": {
+        "self": {
+          "href": "https://dspace7.4science.it/dspace-spring-rest/api/config/harvesting_metadata_configs"
+        }
+      }
+    }
+    
+  }
+}
+```
+
+### Changing Collection Harvesting Settings
+**PUT /api/core/collections/<:uuid>/harvestingSettings**
+
+It updates the harvesting settings for the current collection. This information can only be updated by users with collection administration permissions
+
+A sample json request:
+
+```json
+{
+  "harvest_type": "METADATA_ONLY",
+  "oai_source": "https://dspace.mit.edu/oai/request",
+  "oai_set_id": "col_1721.1_114174",
+  "metadata_config_id": "dc"
+}
+```
+
+A sample json request to disable harvesting is:
+
+```json
+{
+  "harvest_type": "NONE"
+}
+```
+
 ## Creating a collection
 
 **POST /api/core/collections?parent=<:communityUUID>**

--- a/collections.md
+++ b/collections.md
@@ -173,7 +173,7 @@ The harvest_status can be any of:
 * OAI_ERROR
 * UNKNOWN_ERROR
 
-The metadata_config_id can be one of the ids from [Harvesting metadata configuration Endpoints](harvesting_metadata_configs.md)
+The metadata_config_id can be one of the ids from [Harvesting metadata configuration Endpoints](harvestermetadata.md)
 
 A sample json response:
 
@@ -240,7 +240,7 @@ A sample json response if no harvesting is enabled:
     }
   },
   "_embedded": {
-    "metadata_configs": {
+    "harvestermetadata": {
       "configs": [
         {
            "id": "dc",

--- a/collections.md
+++ b/collections.md
@@ -160,6 +160,21 @@ see also the [ResourcePolicies endpoint](resourcepolicies.md)
 
 It returns the harvesting settings for the current collection. This information is only accessible for users with collection administration permissions
 
+The harvest_type can be any of:
+* NONE
+* METADATA_ONLY
+* METADATA_AND_REF
+* METADATA_AND_BITSTREAMS
+
+The harvest_status can be any of:
+* READY
+* BUSY
+* QUEUED
+* OAI_ERROR
+* UNKNOWN_ERROR
+
+The metadata_config_id can be one of the ids from [Harvesting metadata configuration Endpoints](harvesting_metadata_configs.md)
+
 A sample json response:
 
 ```json
@@ -169,7 +184,7 @@ A sample json response:
   "oai_set_id": "col_1721.1_114174",
   "harvest_message": null,
   "metadata_config_id": "dc",
-  "harvest_status": "ready",
+  "harvest_status": "READY",
   "harvest_start_time": null,
   "last_harvested": null,
   "_links": {
@@ -277,6 +292,13 @@ A sample json request to disable harvesting is:
   "harvest_type": "NONE"
 }
 ```
+
+Status codes:
+* 200 OK - if the operation succeeded
+* 401 Forbidden - if you are not authenticated
+* 403 Unauthorized - if you are not logged in with sufficient permissions
+* 404 Not found - if the collection doesn't exist
+* 422 Unprocessable Entity - if the harvest_type or the metadata_config_id is not valid
 
 ## Creating a collection
 

--- a/collections.md
+++ b/collections.md
@@ -156,7 +156,7 @@ The json representation is as follow
 see also the [ResourcePolicies endpoint](resourcepolicies.md)
 
 ### Collection Harvesting Settings
-**GET /api/core/collections/<:uuid>/harvestingSettings**
+**GET /api/core/collections/<:uuid>/harvester**
 
 It returns the harvesting settings for the current collection. This information is only accessible for users with collection administration permissions
 
@@ -189,7 +189,7 @@ A sample json response:
   "last_harvested": null,
   "_links": {
     "self": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/6f944500-c300-449a-9023-a5ad8bd21160/harvestingSettings"
+      "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/6f944500-c300-449a-9023-a5ad8bd21160/harvester"
     }
   },
   "_embedded": {
@@ -213,7 +213,7 @@ A sample json response:
       ],
       "_links": {
         "self": {
-          "href": "https://dspace7.4science.it/dspace-spring-rest/api/config/harvesting_metadata_configs"
+          "href": "https://dspace7.4science.it/dspace-spring-rest/api/config/harvestermetadata"
         }
       }
     }
@@ -236,7 +236,7 @@ A sample json response if no harvesting is enabled:
   "last_harvested": null,
   "_links": {
     "self": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/6f944500-c300-449a-9023-a5ad8bd21160/harvestingSettings"
+      "href": "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/6f944500-c300-449a-9023-a5ad8bd21160/harvester"
     }
   },
   "_embedded": {
@@ -260,7 +260,7 @@ A sample json response if no harvesting is enabled:
       ],
       "_links": {
         "self": {
-          "href": "https://dspace7.4science.it/dspace-spring-rest/api/config/harvesting_metadata_configs"
+          "href": "https://dspace7.4science.it/dspace-spring-rest/api/config/harvestermetadata"
         }
       }
     }
@@ -270,7 +270,7 @@ A sample json response if no harvesting is enabled:
 ```
 
 ### Changing Collection Harvesting Settings
-**PUT /api/core/collections/<:uuid>/harvestingSettings**
+**PUT /api/core/collections/<:uuid>/harvester**
 
 It updates the harvesting settings for the current collection. This information can only be updated by users with collection administration permissions
 

--- a/collections.md
+++ b/collections.md
@@ -173,7 +173,7 @@ The harvest_status can be any of:
 * OAI_ERROR
 * UNKNOWN_ERROR
 
-The metadata_config_id can be one of the ids from [Harvesting metadata configuration Endpoints](harvestermetadata.md)
+The metadata_config_id can be one of the ids from the [Harvester Metadata Endpoint](harvestermetadata.md)
 
 A sample json response:
 

--- a/endpoints.md
+++ b/endpoints.md
@@ -17,6 +17,7 @@
 * [/api/authn/login](https://wiki.duraspace.org/display/DSPACE/REST+Authentication)
 * [/api/authn/logout](https://wiki.duraspace.org/display/DSPACE/REST+Authentication)
 * [/api/authn/status](https://wiki.duraspace.org/display/DSPACE/REST+Authentication)
+* [/api/config/harvestermetadata](harvestermetadata.md)
 * [/api/config/submissiondefinitions](submissiondefinitions.md)
 * [/api/config/submissionsections](submissionsections.md)
 * [/api/config/submissionforms](submissionforms.md)

--- a/harvestermetadata.md
+++ b/harvestermetadata.md
@@ -2,11 +2,11 @@
 [Back to the list of all defined endpoints](endpoints.md)
 
 ## Main Endpoint
-**/api/config/harvesting_metadata_configs**   
+**/api/config/harvestermetadata**   
 
-Provide access to the list of harvesting metadata configurationss (config based).
+Provide access to the list of harvesting metadata configurations (config based).
 
-Example: <http://dspace7.4science.it/dspace-spring-rest/#/dspace-spring-rest/api/config/harvesting_metadata_configs>
+Example: <http://dspace7.4science.it/dspace-spring-rest/#/dspace-spring-rest/api/config/harvestermetadata>
 
 
 A sample json response:
@@ -32,7 +32,7 @@ A sample json response:
   ],
   "_links": {
     "self": {
-      "href": "https://dspace7.4science.it/dspace-spring-rest/api/config/harvesting_metadata_configs"
+      "href": "https://dspace7.4science.it/dspace-spring-rest/api/config/harvestermetadata"
     }
   }
 }

--- a/harvesting_metadata_configs.md
+++ b/harvesting_metadata_configs.md
@@ -1,4 +1,4 @@
-# Collections Endpoints
+# Harvesting metadata configuration Endpoints
 [Back to the list of all defined endpoints](endpoints.md)
 
 ## Main Endpoint

--- a/harvesting_metadata_configs.md
+++ b/harvesting_metadata_configs.md
@@ -1,0 +1,39 @@
+# Collections Endpoints
+[Back to the list of all defined endpoints](endpoints.md)
+
+## Main Endpoint
+**/api/config/harvesting_metadata_configs**   
+
+Provide access to the list of harvesting metadata configurationss (config based).
+
+Example: <http://dspace7.4science.it/dspace-spring-rest/#/dspace-spring-rest/api/config/harvesting_metadata_configs>
+
+
+A sample json response:
+
+```json
+{
+  "configs": [
+    {
+       "id": "dc",
+       "label": "Simple Dublin Core",
+       "nameSpace": "http://www.openarchives.org/OAI/2.0/oai_dc/"
+    },
+    {
+       "id": "qdc",
+       "label": "Qualified Dublin Core",
+       "nameSpace": "http://purl.org/dc/terms/"
+    },
+    {
+       "id": "dim",
+       "label": "DSpace Intermediate Metadata",
+       "nameSpace": "http://www.dspace.org/xmlns/dspace/dim"
+    }
+  ],
+  "_links": {
+    "self": {
+      "href": "https://dspace7.4science.it/dspace-spring-rest/api/config/harvesting_metadata_configs"
+    }
+  }
+}
+```


### PR DESCRIPTION
REST contract for viewing and configuring the OAI Harvesting settings of a collection.

This also includes an endpoint to retrieve a list of all configured supported harvesting formats.

This doesn't include starting the actual harvest action. It can be supported using https://github.com/DSpace/Rest7Contract/pull/17