### PR TITLE
Rename properties and support for name variants

### DIFF
--- a/relationships.md
+++ b/relationships.md
@@ -18,7 +18,7 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
 {
   "id": 530,
   "leftPlace": 1,
-  "leftwardLabel": "Name variant 1",
+  "leftwardValue": "Smith, Jane",
   "rightPlace": 1,
   "type": "relationship",
   "_links": {
@@ -38,8 +38,8 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
   "_embedded": {
     "relationshipType": {
       "id": 1,
-      "leftwardLabel": "isAuthorOfPublication",
-      "rightwardLabel": "isPublicationOfAuthor",
+      "leftwardType": "isAuthorOfPublication",
+      "rightwardType": "isPublicationOfAuthor",
       "leftMinCardinality": 0,
       "leftMaxCardinality": null,
       "rightMinCardinality": 0,
@@ -92,7 +92,7 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
 The [relationship type](relationshiptypes.md) is embedded
 The 2 items are included as HAL links but are not embedded
 
-An optional leftwardLabel and rightwardLabel property can be present. It's omitted when it's null.
+An optional leftwardValue and rightwardValue property can be present. It's omitted when it's null.
 
 ## Creating a relationship
 
@@ -107,7 +107,7 @@ curl -i -X POST 'https://dspace7-entities.atmire.com/rest/api/core/relationships
 
 Including a name variant would result in:
 ```
-curl -i -X POST 'https://dspace7-entities.atmire.com/rest/api/core/relationships?relationshipType=1&leftwardLabel=Name%20variant%201' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://dspace7-entities.atmire.com/rest/api/core/items/12623672-25a9-4df2-ab36-699c4c240c7e \n https://dspace7-entities.atmire.com/rest/api/core/items/5a3f7c7a-d3df-419c-8a2-f00ede62c60a'
+curl -i -X POST 'https://dspace7-entities.atmire.com/rest/api/core/relationships?relationshipType=1&leftwardValue=Name%20variant%201' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://dspace7-entities.atmire.com/rest/api/core/items/12623672-25a9-4df2-ab36-699c4c240c7e \n https://dspace7-entities.atmire.com/rest/api/core/items/5a3f7c7a-d3df-419c-8a2-f00ede62c60a'
 ```
 
 The uri-list should always contain exactly 2 items. The first item will be used as the left Item. The second item will be used as the right Item.
@@ -151,7 +151,7 @@ Error codes:
 
 Update the name variant or the place:
 ```
-curl -i -X PUT 'https://dspace7-entities.atmire.com/rest/api/core/relationships/891' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:application/json" --data '{ "leftPlace": 1, "leftwardLabel": "Name variant 1", "rightPlace": 1, "rightwardLabel": null }'
+curl -i -X PUT 'https://dspace7-entities.atmire.com/rest/api/core/relationships/891' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:application/json" --data '{ "leftPlace": 1, "leftwardValue": "Smith, Jane", "rightPlace": 1, "rightwardValue": null }'
 ```
 
 Omitted properties will be removed.
@@ -197,8 +197,8 @@ It would respond with
         "_embedded": {
           "relationshipType": {
             "id": 5,
-            "leftwardLabel": "isOrgUnitOfPerson",
-            "rightwardLabel": "isPersonOfOrgUnit",
+            "leftwardType": "isOrgUnitOfPerson",
+            "rightwardType": "isPersonOfOrgUnit",
             "leftMinCardinality": 0,
             "leftMaxCardinality": null,
             "rightMinCardinality": 0,
@@ -270,8 +270,8 @@ It would respond with
         "_embedded": {
           "relationshipType": {
             "id": 5,
-            "leftwardLabel": "isOrgUnitOfPerson",
-            "rightwardLabel": "isPersonOfOrgUnit",
+            "leftwardType": "isOrgUnitOfPerson",
+            "rightwardType": "isPersonOfOrgUnit",
             "leftMinCardinality": 0,
             "leftMaxCardinality": null,
             "rightMinCardinality": 0,

--- a/relationships.md
+++ b/relationships.md
@@ -19,7 +19,7 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
   "id": 530,
   "relationshipTypeId": 0,
   "leftPlace": 1,
-  "leftWardLabel": "Name variant 1",
+  "leftwardLabel": "Name variant 1",
   "rightPlace": 1,
   "type": "relationship",
   "_links": {
@@ -39,8 +39,8 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
   "_embedded": {
     "relationshipType": {
       "id": 1,
-      "leftWardLabel": "isAuthorOfPublication",
-      "rightWardLabel": "isPublicationOfAuthor",
+      "leftwardLabel": "isAuthorOfPublication",
+      "rightwardLabel": "isPublicationOfAuthor",
       "leftMinCardinality": 0,
       "leftMaxCardinality": null,
       "rightMinCardinality": 0,
@@ -93,7 +93,7 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
 The [relationship type](relationshiptypes.md) is embedded
 The 2 items are included as HAL links but are not embedded
 
-An optional leftWardLabel and rightWardLabel property can be present. It's omitted when it's null.
+An optional leftwardLabel and rightwardLabel property can be present. It's omitted when it's null.
 
 ## Creating a relationship
 
@@ -108,7 +108,7 @@ curl -i -X POST 'https://dspace7-entities.atmire.com/rest/api/core/relationships
 
 Including a name variant would result in:
 ```
-curl -i -X POST 'https://dspace7-entities.atmire.com/rest/api/core/relationships?relationshipType=1&leftWardLabel=Name%20variant%201' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://dspace7-entities.atmire.com/rest/api/core/items/12623672-25a9-4df2-ab36-699c4c240c7e \n https://dspace7-entities.atmire.com/rest/api/core/items/5a3f7c7a-d3df-419c-8a2-f00ede62c60a'
+curl -i -X POST 'https://dspace7-entities.atmire.com/rest/api/core/relationships?relationshipType=1&leftwardLabel=Name%20variant%201' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://dspace7-entities.atmire.com/rest/api/core/items/12623672-25a9-4df2-ab36-699c4c240c7e \n https://dspace7-entities.atmire.com/rest/api/core/items/5a3f7c7a-d3df-419c-8a2-f00ede62c60a'
 ```
 
 The uri-list should always contain exactly 2 items. The first item will be used as the left Item. The second item will be used as the right Item.
@@ -152,10 +152,10 @@ Error codes:
 
 Update the name variant or the place:
 ```
-curl -i -X PUT 'https://dspace7-entities.atmire.com/rest/api/core/relationships/891' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:application/json" --data '{ "leftPlace": 1, "leftWardLabel": "Name variant 1", "rightPlace": 1, "rightWardLabel": null }'
+curl -i -X PUT 'https://dspace7-entities.atmire.com/rest/api/core/relationships/891' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:application/json" --data '{ "leftPlace": 1, "leftwardLabel": "Name variant 1", "rightPlace": 1, "rightwardLabel": null }'
 ```
 
-Omitted properties will not be updated. Removing a name variant would require setting it to null.
+Omitted properties will be removed.
 
 Error codes:
 * 200 OK - if the operation succeeded
@@ -199,8 +199,8 @@ It would respond with
         "_embedded": {
           "relationshipType": {
             "id": 5,
-            "leftWardLabel": "isOrgUnitOfPerson",
-            "rightWardLabel": "isPersonOfOrgUnit",
+            "leftwardLabel": "isOrgUnitOfPerson",
+            "rightwardLabel": "isPersonOfOrgUnit",
             "leftMinCardinality": 0,
             "leftMaxCardinality": null,
             "rightMinCardinality": 0,
@@ -273,8 +273,8 @@ It would respond with
         "_embedded": {
           "relationshipType": {
             "id": 5,
-            "leftWardLabel": "isOrgUnitOfPerson",
-            "rightWardLabel": "isPersonOfOrgUnit",
+            "leftwardLabel": "isOrgUnitOfPerson",
+            "rightwardLabel": "isPersonOfOrgUnit",
             "leftMinCardinality": 0,
             "leftMaxCardinality": null,
             "rightMinCardinality": 0,

--- a/relationships.md
+++ b/relationships.md
@@ -17,7 +17,6 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
 ```json
 {
   "id": 530,
-  "relationshipTypeId": 0,
   "leftPlace": 1,
   "leftwardLabel": "Name variant 1",
   "rightPlace": 1,
@@ -177,7 +176,6 @@ It would respond with
       {
         "id": 590,
         "leftId": "f2235aa6-6fe7-4174-a690-598b72dd8e44",
-        "relationshipTypeId": 0,
         "rightId": "d30de96b-1e76-40ae-8ef9-ab426b6f9763",
         "leftPlace": 1,
         "rightPlace": 2,
@@ -251,7 +249,6 @@ It would respond with
       {
         "id": 589,
         "leftId": "5a3f7c7a-d3df-419c-b8a2-f00ede62c60a",
-        "relationshipTypeId": 0,
         "rightId": "c216201f-ed10-4361-b0e0-5a065405bd3e",
         "leftPlace": 2,
         "rightPlace": 1,

--- a/relationships.md
+++ b/relationships.md
@@ -39,8 +39,8 @@ The leftId and rightId parameter in JSON may still be present, but they will be 
   "_embedded": {
     "relationshipType": {
       "id": 1,
-      "leftLabel": "isAuthorOfPublication",
-      "rightLabel": "isPublicationOfAuthor",
+      "leftWardLabel": "isAuthorOfPublication",
+      "rightWardLabel": "isPublicationOfAuthor",
       "leftMinCardinality": 0,
       "leftMaxCardinality": null,
       "rightMinCardinality": 0,
@@ -175,8 +175,8 @@ It would respond with
         "_embedded": {
           "relationshipType": {
             "id": 5,
-            "leftLabel": "isOrgUnitOfPerson",
-            "rightLabel": "isPersonOfOrgUnit",
+            "leftWardLabel": "isOrgUnitOfPerson",
+            "rightWardLabel": "isPersonOfOrgUnit",
             "leftMinCardinality": 0,
             "leftMaxCardinality": null,
             "rightMinCardinality": 0,
@@ -249,8 +249,8 @@ It would respond with
         "_embedded": {
           "relationshipType": {
             "id": 5,
-            "leftLabel": "isOrgUnitOfPerson",
-            "rightLabel": "isPersonOfOrgUnit",
+            "leftWardLabel": "isOrgUnitOfPerson",
+            "rightWardLabel": "isPersonOfOrgUnit",
             "leftMinCardinality": 0,
             "leftMaxCardinality": null,
             "rightMinCardinality": 0,

--- a/relationships.md
+++ b/relationships.md
@@ -12,14 +12,14 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
 ## Single Relationship
 **/api/core/relationships/<:id>**
 
-A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspace7-entities.atmire.com/rest/api/core/relationships/530
-The leftId and rightId parameter in JSON may still be present, but they will be removed soon (requires other PRs to be merged first)
+A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspace7-entities.atmire.com/rest/api/core/relationships/1117
 
 ```json
 {
   "id": 530,
   "relationshipTypeId": 0,
   "leftPlace": 1,
+  "leftWardLabel": "Name variant 1",
   "rightPlace": 1,
   "type": "relationship",
   "_links": {
@@ -93,6 +93,8 @@ The leftId and rightId parameter in JSON may still be present, but they will be 
 The [relationship type](relationshiptypes.md) is embedded
 The 2 items are included as HAL links but are not embedded
 
+An optional leftWardLabel and rightWardLabel property can be present. It's omitted when it's null.
+
 ## Creating a relationship
 
 **POST /api/core/relationships?relationshipType=<:relationshipType>**
@@ -104,6 +106,11 @@ A sample CURL command would be:
 curl -i -X POST 'https://dspace7-entities.atmire.com/rest/api/core/relationships?relationshipType=1' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://dspace7-entities.atmire.com/rest/api/core/items/12623672-25a9-4df2-ab36-699c4c240c7e \n https://dspace7-entities.atmire.com/rest/api/core/items/5a3f7c7a-d3df-419c-8a2-f00ede62c60a'
 ```
 
+Including a name variant would result in:
+```
+curl -i -X POST 'https://dspace7-entities.atmire.com/rest/api/core/relationships?relationshipType=1&leftWardLabel=Name%20variant%201' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://dspace7-entities.atmire.com/rest/api/core/items/12623672-25a9-4df2-ab36-699c4c240c7e \n https://dspace7-entities.atmire.com/rest/api/core/items/5a3f7c7a-d3df-419c-8a2-f00ede62c60a'
+```
+
 The uri-list should always contain exactly 2 items. The first item will be used as the left Item. The second item will be used as the right Item.
 The relationshipType parameter is mandatory as well
 
@@ -112,7 +119,7 @@ The relationshipType parameter is mandatory as well
 * 403 Unauthorized - if you are not logged in with sufficient permissions
 * 422 Unprocessable Entity - if one of the items doesn't exist
 
-## Updating a relationship
+## Updating the items in a relationship
 
 **PUT /api/core/relationships/<:id>/<:leftVsRightItem>**
 
@@ -138,6 +145,23 @@ Error codes:
 * 403 Unauthorized - if you are not logged in with sufficient permissions
 * 404 Not found - if the relationships doesn't exist
 * 422 Unprocessable Entity - if the item doesn't exist, or if the amount of items is not 1
+
+## Updating the metadata of a relationship
+
+**PUT /api/core/relationships/<:id>**
+
+Update the name variant or the place:
+```
+curl -i -X PUT 'https://dspace7-entities.atmire.com/rest/api/core/relationships/891' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:application/json" --data '{ "leftPlace": 1, "leftWardLabel": "Name variant 1", "rightPlace": 1, "rightWardLabel": null }'
+```
+
+Omitted properties will not be updated. Removing a name variant would require setting it to null.
+
+Error codes:
+* 200 OK - if the operation succeeded
+* 401 Forbidden - if you are not authenticated
+* 403 Unauthorized - if you are not logged in with sufficient permissions
+* 404 Not found - if the relationship doesn't exist
 
 ## Relationships per Relationship type
 **/api/core/relationships/search/byLabel?label=<:relationshipname>**

--- a/relationshiptypes.md
+++ b/relationshiptypes.md
@@ -18,8 +18,8 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
 ```json
 {
   "id": 1,
-  "leftLabel": "isAuthorOfPublication",
-  "rightLabel": "isPublicationOfAuthor",
+  "leftWardLabel": "isAuthorOfPublication",
+  "rightWardLabel": "isPublicationOfAuthor",
   "leftMinCardinality": 0,
   "leftMaxCardinality": null,
   "rightMinCardinality": 0,

--- a/relationshiptypes.md
+++ b/relationshiptypes.md
@@ -18,8 +18,8 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
 ```json
 {
   "id": 1,
-  "leftWardLabel": "isAuthorOfPublication",
-  "rightWardLabel": "isPublicationOfAuthor",
+  "leftwardLabel": "isAuthorOfPublication",
+  "rightwardLabel": "isPublicationOfAuthor",
   "leftMinCardinality": 0,
   "leftMaxCardinality": null,
   "rightMinCardinality": 0,

--- a/relationshiptypes.md
+++ b/relationshiptypes.md
@@ -18,8 +18,8 @@ A sample can be found at https://dspace7-entities.atmire.com/rest/#https://dspac
 ```json
 {
   "id": 1,
-  "leftwardLabel": "isAuthorOfPublication",
-  "rightwardLabel": "isPublicationOfAuthor",
+  "leftwardType": "isAuthorOfPublication",
+  "rightwardType": "isPublicationOfAuthor",
   "leftMinCardinality": 0,
   "leftMaxCardinality": null,
   "rightMinCardinality": 0,


### PR DESCRIPTION
This PR contains two minor changes to the REST contract:
* The leftLabel is renamed to leftWardLabel at the relationship type level to clarify e.g. isAuthorOfPublication is the name of the arrow pointing from the right item to the left item. The term leftLabel created some confusion in the past.
* Support for name variants has also been included with an leftWardLabel property at the relationship level to specify an alternative name used in the arrow pointing from the right item to the left item.

The name variants will be exposed in the virtual metadata as well, so this direct property will primarily be used for storing and updating the label.