### PR TITLE
Update bitstream properties and format

### DIFF
--- a/bitstreams.md
+++ b/bitstreams.md
@@ -37,13 +37,86 @@ Exposed links:
 
 Bitstream metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).
 
+Additional bitstream properties can be modified via Patch as described below.
+
+### Replace
+The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation to set not yet initialized information must return an error. See [general errors on PATCH requests](patch.md)
+
+To change the bundle of a bitstream:
+
+`curl --data '[ { "op": "replace", "path": "/bundleName", "value": "TEST"}]' -H "Authorization: Bearer ..." -H "content-type: application/json" -X PATCH ${dspace7-url}/api/core/bitstreams/${uuid}`
+
+For example, starting with the following bitstream data:
+```json
+{
+  "name" : "test.zip",
+  "bundleName" : "ORIGINAL",
+  "sequenceId" : 5
+}
+```
+the change bundleName operation will result in:
+```json
+{
+  "name" : "test.zip",
+  "bundleName" : "TEST",
+  "sequenceId" : 5
+}
+```
+
+To change the sequenceId:
+
+`curl --data '[ { "op": "replace", "path": "/sequenceId", "value": 2}]' -H "Authorization: Bearer ..." -H "content-type: application/json" -X PATCH ${dspace7-url}/api/core/bitstreams/${uuid}`
+
+
+For example, starting with the following bitstream data:
+```json
+{
+  "name" : "test.zip",
+  "bundleName" : "ORIGINAL",
+  "sequenceId" : 5
+}
+```
+the change sequenceId operation will result in:
+```json
+{
+  "name" : "test.zip",
+  "bundleName" : "ORIGINAL",
+  "sequenceId" : 2
+}
+```
+
+Status codes:
+* 200 OK - if the operation succeed
+* 401 Forbidden - if you are not authenticated
+* 403 Unauthorized - if you are not logged in with sufficient permissions
+* 404 Not found - if the bitstream doesn't exist
+* 422 Unprocessable Entity - if the bundleName was removed, or the sequenceId already exists for the item containing the bitstream
+
 ## Linked entities
 ### Format
-**/api/core/bitstreams/<:uuid>/format**
+**GET /api/core/bitstreams/<:uuid>/format**
 
 Example: <http://dspace7.4science.it/dspace-spring-rest/#http://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/8d33bdfb-e7ba-43e6-a93a-f445b7e8a1e2/format>
 
 It returns the format of the bitstream
+
+**PUT /api/core/bitstreams/<:uuid>/format**
+
+Update the bitstream format of the bitstream
+
+Sample CURL command:
+```
+curl -i -X PUT 'https://dspace7-entities.atmire.com/rest/api/core/bitstreams/6ba01288-8a5a-4acf-96f1-fd0730424a1f' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://dspace7-entities.atmire.com/rest/api/core/bitstreamformats/6'
+```
+
+The uri-list should always contain exactly 1 bitstream format. This bitstream format will be assigned to the bitstream
+
+Error codes:
+* 200 OK - if the operation succeeded
+* 401 Forbidden - if you are not authenticated
+* 403 Unauthorized - if you are not logged in with sufficient permissions
+* 404 Not found - if the bitstream doesn't exist
+* 422 Unprocessable Entity - if the bitstream format doesn't exist, or if the amount of bitstream formats is not 1
 
 ### Content
 **/api/core/bitstreams/<:uuid>/content**

--- a/bitstreams.md
+++ b/bitstreams.md
@@ -42,27 +42,6 @@ Additional bitstream properties can be modified via Patch as described below.
 ### Replace
 The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation to set not yet initialized information must return an error. See [general errors on PATCH requests](patch.md)
 
-To change the bundle of a bitstream:
-
-`curl --data '[ { "op": "replace", "path": "/bundleName", "value": "TEST"}]' -H "Authorization: Bearer ..." -H "content-type: application/json" -X PATCH ${dspace7-url}/api/core/bitstreams/${uuid}`
-
-For example, starting with the following bitstream data:
-```json
-{
-  "name" : "test.zip",
-  "bundleName" : "ORIGINAL",
-  "sequenceId" : 5
-}
-```
-the change bundleName operation will result in:
-```json
-{
-  "name" : "test.zip",
-  "bundleName" : "TEST",
-  "sequenceId" : 5
-}
-```
-
 To change the sequenceId:
 
 `curl --data '[ { "op": "replace", "path": "/sequenceId", "value": 2}]' -H "Authorization: Bearer ..." -H "content-type: application/json" -X PATCH ${dspace7-url}/api/core/bitstreams/${uuid}`
@@ -90,7 +69,7 @@ Status codes:
 * 401 Forbidden - if you are not authenticated
 * 403 Unauthorized - if you are not logged in with sufficient permissions
 * 404 Not found - if the bitstream doesn't exist
-* 422 Unprocessable Entity - if the bundleName was removed, or the sequenceId already exists for the item containing the bitstream
+* 422 Unprocessable Entity - if the sequenceId already exists for the item containing the bitstream
 
 ## Linked entities
 ### Format
@@ -106,17 +85,17 @@ Update the bitstream format of the bitstream
 
 Sample CURL command:
 ```
-curl -i -X PUT 'https://dspace7-entities.atmire.com/rest/api/core/bitstreams/6ba01288-8a5a-4acf-96f1-fd0730424a1f' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://dspace7-entities.atmire.com/rest/api/core/bitstreamformats/6'
+curl -i -X PUT 'https://dspace7-entities.atmire.com/rest/api/core/bitstreams/6ba01288-8a5a-4acf-96f1-fd0730424a1f/format' -H 'Authorization: Bearer eyJhbGciO…' -H "Content-Type:text/uri-list" --data 'https://dspace7-entities.atmire.com/rest/api/core/bitstreamformats/6'
 ```
 
 The uri-list should always contain exactly 1 bitstream format. This bitstream format will be assigned to the bitstream
 
 Error codes:
 * 200 OK - if the operation succeeded
+* 400 Bad Request - if the bitstream format doesn't exist, or if the amount of bitstream formats is not 1
 * 401 Forbidden - if you are not authenticated
 * 403 Unauthorized - if you are not logged in with sufficient permissions
 * 404 Not found - if the bitstream doesn't exist
-* 422 Unprocessable Entity - if the bitstream format doesn't exist, or if the amount of bitstream formats is not 1
 
 ### Content
 **/api/core/bitstreams/<:uuid>/content**

--- a/bitstreams.md
+++ b/bitstreams.md
@@ -37,40 +37,6 @@ Exposed links:
 
 Bitstream metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).
 
-Additional bitstream properties can be modified via Patch as described below.
-
-### Replace
-The replace operation allows to replace *existent* information with new one. Attempt to use the replace operation to set not yet initialized information must return an error. See [general errors on PATCH requests](patch.md)
-
-To change the sequenceId:
-
-`curl --data '[ { "op": "replace", "path": "/sequenceId", "value": 2}]' -H "Authorization: Bearer ..." -H "content-type: application/json" -X PATCH ${dspace7-url}/api/core/bitstreams/${uuid}`
-
-
-For example, starting with the following bitstream data:
-```json
-{
-  "name" : "test.zip",
-  "bundleName" : "ORIGINAL",
-  "sequenceId" : 5
-}
-```
-the change sequenceId operation will result in:
-```json
-{
-  "name" : "test.zip",
-  "bundleName" : "ORIGINAL",
-  "sequenceId" : 2
-}
-```
-
-Status codes:
-* 200 OK - if the operation succeed
-* 401 Forbidden - if you are not authenticated
-* 403 Unauthorized - if you are not logged in with sufficient permissions
-* 404 Not found - if the bitstream doesn't exist
-* 422 Unprocessable Entity - if the sequenceId already exists for the item containing the bitstream
-
 ## Linked entities
 ### Format
 **GET /api/core/bitstreams/<:uuid>/format**

--- a/bitstreams.md
+++ b/bitstreams.md
@@ -63,6 +63,13 @@ Error codes:
 * 403 Unauthorized - if you are not logged in with sufficient permissions
 * 404 Not found - if the bitstream doesn't exist
 
+Keep in mind that there's a change to dc.format in the API related to bitstream formats:
+* setting the bitstream format to a known type removes dc.format in the bitstream metadata
+* setting the bitstream format to unknown also removes dc.format in the bitstream metadata
+* setting dc.format in the metadata will never implicitly change the bitstream format to unknown
+* setting dc.format in the metadata will require a separate REST call, it's not part of the /format request
+* setting dc.format will currently not be denied when the format is known, but it's not recommended to set it as such
+
 ### Content
 **/api/core/bitstreams/<:uuid>/content**
 


### PR DESCRIPTION
The bitstream currently has a PATCH feature for the metadata, but doesn't support any other changes (e.g. changing the bitstream format)

This PR contains all changes which can be performed to a bitstream except for the bitstream order.
For the bitstream order, a separate PR will be created since the order is determined at the bundle level