### PR TITLE
Defining relationships in submission forms: selectableRelationship should not be an array

### DIFF
--- a/submissionforms.md
+++ b/submissionforms.md
@@ -147,13 +147,12 @@ Provide detailed information about a specific input-form. The JSON response docu
           "mandatory": false,
           "repeatable": false,
           "hints": "Select the journal related to this volume.",
-          "selectableRelationship": [
+          "selectableRelationship": 
             {
               "relationship": "isVolumeOfJournal",
               "filter": "creativework.publisher:somepublishername",
               "search-configuration": "periodicalConfiguration"
             }
-          ]
         }
       ]
     },
@@ -168,13 +167,12 @@ Provide detailed information about a specific input-form. The JSON response docu
           "repeatable": true,
           "mandatoryMessage": "At least one author (plain text or relationship) is required",
           "hints": "Add an author",
-          "selectableRelationship": [
+          "selectableRelationship": 
             {
               "relationship": "isAuthorOfPublication",
               "filter": null,
               "search-configuration": "personConfiguration"
-            }
-          ],
+            },
           "selectableMetadata": [
             {
               "metadata": "dc.contributor.author",

--- a/submissionforms.md
+++ b/submissionforms.md
@@ -147,12 +147,11 @@ Provide detailed information about a specific input-form. The JSON response docu
           "mandatory": false,
           "repeatable": false,
           "hints": "Select the journal related to this volume.",
-          "selectableRelationship": 
-            {
-              "relationship": "isVolumeOfJournal",
-              "filter": "creativework.publisher:somepublishername",
-              "search-configuration": "periodicalConfiguration"
-            }
+          "selectableRelationship": {
+            "relationship": "isVolumeOfJournal",
+            "filter": "creativework.publisher:somepublishername",
+            "search-configuration": "periodicalConfiguration"
+          }
         }
       ]
     },
@@ -167,12 +166,11 @@ Provide detailed information about a specific input-form. The JSON response docu
           "repeatable": true,
           "mandatoryMessage": "At least one author (plain text or relationship) is required",
           "hints": "Add an author",
-          "selectableRelationship": 
-            {
-              "relationship": "isAuthorOfPublication",
-              "filter": null,
-              "search-configuration": "personConfiguration"
-            },
+          "selectableRelationship": {
+            "relationship": "isAuthorOfPublication",
+            "filter": null,
+            "search-configuration": "personConfiguration"
+          },
           "selectableMetadata": [
             {
               "metadata": "dc.contributor.author",


### PR DESCRIPTION
This is a correction to https://github.com/DSpace/Rest7Contract/pull/64

The selectableRelationship was accidentally defined as an array (similar to selectableMetadata). Only one selectableRelationship was supposed to be used.