### PR TITLE
Entities: Creating an archived item from an external source

### DIFF
--- a/items.md
+++ b/items.md
@@ -136,6 +136,8 @@ An example curl call:
  --data "https://dspace7.4science.it/dspace-spring-rest/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
 ```
 
+Only one external entry value should be present. If multiple external entry values are present, a 400 bad request will be thrown
+
 ## Updating item metadata
 
 **PUT /api/core/items/<:uuid>**

--- a/items.md
+++ b/items.md
@@ -123,19 +123,17 @@ Administrators can directly create an archived item (bypassing the workflow). Th
 ```
 
 ### Creating an archived item from an external source
-**POST /api/core/items**
+**POST /api/core/items?owningCollection=<:uuid>**
 
 Administrators can directly create an archived item (bypassing the workflow) from an external source. The content-type is uri-list.
 
-The URI-list should contain:
-* The owning collection
-* The [external entry value](external-authority-sources.md) whose metadata should be imported
+The URI-list should contain the [external entry value](external-authority-sources.md) whose metadata should be imported
 
 An example curl call:
 ```
- curl -i -X POST https://dspace7.4science.it/dspace-spring-rest/api/core/items \
+ curl -i -X POST https://dspace7.4science.it/dspace-spring-rest/api/core/items?owningCollection=1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb \
  -H "Content-Type:text/uri-list" \
- --data "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb \n https://dspace7.4science.it/dspace-spring-rest/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
+ --data "https://dspace7.4science.it/dspace-spring-rest/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
 ```
 
 ## Updating item metadata

--- a/items.md
+++ b/items.md
@@ -82,10 +82,9 @@ Exposed links:
 * relationships: the relationships to other items
  
 ## Creating an archived item
-
 **POST /api/core/items?owningCollection=<:uuid>**
 
-Administrators can directly create an archived item (bypassing the workflow). An example JSON can be seen below:
+Administrators can directly create an archived item (bypassing the workflow). The content-type is JSON. An example JSON can be seen below:
 
 ```json
 {
@@ -121,6 +120,22 @@ Administrators can directly create an archived item (bypassing the workflow). An
   "withdrawn": false,
   "type": "item"
 }
+```
+
+### Creating an archived item from an external source
+**POST /api/core/items**
+
+Administrators can directly create an archived item (bypassing the workflow) from an external source. The content-type is uri-list.
+
+The URI-list should contain:
+* The owning collection
+* The [external entry value](external-authority-sources.md) whose metadata should be imported
+
+An example curl call:
+```
+ curl -i -X POST https://dspace7.4science.it/dspace-spring-rest/api/core/items \
+ -H "Content-Type:text/uri-list" \
+ --data "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb \n https://dspace7.4science.it/dspace-spring-rest/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
 ```
 
 ## Updating item metadata


### PR DESCRIPTION
This Rest Contract is a continuation of https://github.com/DSpace/Rest7Contract/pull/74
It ensures admins can create a new entity based on an external source.
This uses a POST on the /api/core/items, but instead of using a JSON content-type (with metadata), it uses a URI-list (with the collection and external source)

The item is immediately archived, making this only possible for admins