### PR TITLE
DS-4281: Metadata suggestions in the live import

### DIFF
--- a/metadata-suggestions.md
+++ b/metadata-suggestions.md
@@ -7,10 +7,10 @@
 - [Main Endpoint](#main-endpoint)
 - [Single suggestion endpoint](#single-suggestion-endpoint)
 - [Linked entities](#linked-entities)
-	- [External source entries](#external-source-entries)
+	- [Live import entries](#live-import-entries)
 	- [Single entry](#single-entry)
 	- [Changes for a single entry](#changes-for-a-single-entry)
-- [Changes suggested from the external source](#changes-suggested-from-the-external-source)
+- [Changes suggested from the live import](#changes-suggested-from-the-live-import)
 	- [Introduction](#introduction)
 	- [Adding metadata](#adding-metadata)
 	- [Replacing metadata](#replacing-metadata)
@@ -18,15 +18,15 @@
 ## Introduction
 
 This contract allows for suggesting metadata changes to an in-submission or in-workflow item.
-The user can choose an external source to use for suggesting the metadata (e.g. PubMed for a medical publication, ORCID for an author, a RIS file for uploaded metadata).
-The external source will suggest matches, and will suggest metadata changes if the match is accepted by the user.
-A full metadata description of the data from the external source is displayed in combination to the suggested changes to the current item.
+The user can choose a live import source to use for suggesting the metadata (e.g. PubMed for a medical publication, ORCID for an author, a RIS file for uploaded metadata).
+The live import source will suggest matches, and will suggest metadata changes if the match is accepted by the user.
+A full metadata description of the data from the live import source is displayed in combination to the suggested changes to the current item.
 
 ## Main Endpoint
 **/api/integration/metadata-suggestions**
 
-Provide access to the configured external sources which can suggest metadata.
-It returns the list of existent external sources.
+Provide access to the configured live import sources which can suggest metadata.
+It returns the list of existent live import sources.
 
 Parameters (or should this be retrieved from the submission forms?):
 * workspaceitem
@@ -124,7 +124,7 @@ Example:
 ## Single suggestion endpoint
 **/api/integration/metadata-suggestions/<:suggestion-name>**
 
-Provide detailed information about a specific external source. The JSON response document is as follow
+Provide detailed information about a specific live import source. The JSON response document is as follow
 ```json
 {
     "id": "pubmed",
@@ -145,30 +145,30 @@ Provide detailed information about a specific external source. The JSON response
 ```
 
 Properties:
-* query-based: if the external source uses a query to suggest information to import
-* file-based: if the external source uses a file to suggest information to import
-* metadata-based: if the external source uses the current item metadata to suggest information to import
+* query-based: if the live import source uses a query to suggest information to import
+* file-based: if the live import source uses a file to suggest information to import
+* metadata-based: if the live import source uses the current item metadata to suggest information to import
 
 Exposed links:
-* entries: the list of values managed by the external source
+* entries: the list of values managed by the live import source
 
 ## Linked entities
-### External source entries
+### Live import entries
 **/api/integration/metadata-suggestions/<:suggestion-name>/entries**
 
-It returns the filtered entries managed by the external source, see below
+It returns the filtered entries managed by the live import source, see below
 
 The supported parameters are:
-* page, size [see pagination](README.md#Pagination) if supported by the external source
+* page, size [see pagination](README.md#Pagination) if supported by the live import source
 * query: the terms, keywords or prefix to search. Applicable for sources where "query-based" is true
 * bitstream: the bitstream ID to process. Applicable for sources where "file-based" is true
 * use-metadata: enable metadata based search (true or false, defaults to false). Applicable for sources where "metadata-based" is true
 * workspaceitem: the current workspace item ID (mutually exclusive with workflowitem)
 * workflowitem: the current workflow item ID (mutually exclusive with workspaceitem)
 
-It returns the entries in the external source matching the query, bitstream or item metadata
+It returns the entries in the live import source matching the query, bitstream or item metadata
 
-sample for an external source /api/integration/metadata-suggestions/orcid/entries?query=Smith&size=2
+sample for a live import source /api/integration/metadata-suggestions/orcid/entries?query=Smith&size=2
 ```json
 {
   "_embedded": {
@@ -291,9 +291,9 @@ Parameters:
 * workspaceitem: the current workspace item ID (mutually exclusive with workflowitem)
 * workflowitem: the current workflow item ID (mutually exclusive with workspaceitem)
 
-It returns the data from one entry in an external source
+It returns the data from one entry in a live import source
 
-sample for an external source /api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436
+sample for a live import source /api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436
 ```json
 {
   "id": "0000-0002-4271-0436",
@@ -375,7 +375,7 @@ Parameters:
 
 It returns the suggested metadata changes from one entry to be applied to the given item
 
-sample for an external source /api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436/changes
+sample for a live import source /api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436/changes
 ```json
 {
   "changes" : [
@@ -402,7 +402,7 @@ The suggested changes are based on the current item:
 * It takes the current metadata of the item into account (don't suggest to add a title which is already present)
 * It takes the submission forms into account (don't suggest to change metadata fields which are not editable based on input forms, only one value for a non-repeatable field)
 
-## Changes suggested from the external source
+## Changes suggested from the live import
 ### Introduction
 
 The live import can suggest metadata changes.

--- a/metadata-suggestions.md
+++ b/metadata-suggestions.md
@@ -592,7 +592,8 @@ Example response, replacing the the second `dc.contributor.author` name variant:
 }
 ```
 
-If this patch is applied hereafter, the new metadata state is:
+The above example includes two possible operations: an option to replace the namevariant, and an option to add the newvalue as an additional author.
+Assuming the client chooses the first operation (replace the namevariant), the new metadata state is:
 
 ```json
 {

--- a/metadata-suggestions.md
+++ b/metadata-suggestions.md
@@ -158,7 +158,6 @@ Exposed links:
 ## Linked entities
 ### External source entries
 **/api/integration/metadata-suggestions/<:suggestion-name>/entries**
-**/api/submission/workflowitems/<:id>/metadata-suggestions/<:suggestion-name>/entries**
 
 It returns the filtered entries managed by the external source, see below
 

--- a/metadata-suggestions.md
+++ b/metadata-suggestions.md
@@ -9,11 +9,13 @@
 - [Linked entities](#linked-entities)
 	- [Live import entries](#live-import-entries)
 	- [Single entry](#single-entry)
-	- [Changes for a single entry](#changes-for-a-single-entry)
+	- [Differences for a single entry](#differences-for-a-single-entry)
 - [Changes suggested from the live import](#changes-suggested-from-the-live-import)
 	- [Introduction](#introduction)
 	- [Adding metadata](#adding-metadata)
 	- [Replacing metadata](#replacing-metadata)
+	- [Replacing name variants](#replacing-name-variants)
+	- [Adding relationships](#adding-relationships)
 
 ## Introduction
 
@@ -220,8 +222,8 @@ sample for a live import source /api/integration/metadata-suggestions/orcid/entr
           "self": {
             "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436"
           },
-          "changes": {
-            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436/changes"
+          "differences": {
+            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValueDifferences/0000-0002-4271-0436"
           }
         }
       },
@@ -272,8 +274,8 @@ sample for a live import source /api/integration/metadata-suggestions/orcid/entr
           "self": {
             "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0003-3681-2038"
           },
-         "changes": {
-           "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0003-3681-2038/changes"
+         "differences": {
+           "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValueDifferences/0000-0003-3681-2038"
          }
         }
       }
@@ -282,7 +284,7 @@ sample for a live import source /api/integration/metadata-suggestions/orcid/entr
 }
 ```
 
-The changes are explained below, and won't be embedded in this endpoint.
+The differences are explained below, and won't be embedded in this endpoint.
 
 ### Single entry
 **/api/integration/metadata-suggestions/<:suggestion-name>/entryValues/<:entry-id>**  
@@ -343,31 +345,39 @@ sample for a live import source /api/integration/metadata-suggestions/orcid/entr
     "self": {
       "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436"
     },
-    "changes": {
-      "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436/changes"
+    "differences": {
+      "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValueDifferences/0000-0002-4271-0436"
     }
   },
   "_embedded" : {
-     "changes" : [
-      {
-        "op": "add",
-        "path": "/metadata/dc.identifier.orcid",
-        "value": [ { "value": "0000-0002-4271-0436" } ]
-      },
-      {
-        "op": "add",
-        "path": "/metadata/dc.identifier.uri/-",
-        "value": [ { "value": "https://orcid.org/0000-0002-4271-0436" } ]
-      }
-     ]
+     "differences" : {
+         "dc.identifier.orcid" : {
+           "currentvalues" : [],
+           "suggestions" : [
+             {
+               "operations": [ "add" ],
+               "newvalue": "0000-0002-4271-0436"
+             }
+           ]
+         },
+         "dc.identifier.uri" : {
+           "currentvalues" : [ "https://profiles.utsouthwestern.edu/profile/16780/dean-smith.html" ],
+           "suggestions" : [
+             {
+               "operations": [ "add", "replace/0" ],
+               "newvalue": "https://orcid.org/0000-0002-4271-0436"
+             }
+           ]
+         }
+     }
   }
 }
 ```
 
-The changes embedded are the suggested metadata changes to be applied to the given item
+The differences embedded are the suggested metadata changes to be applied to the given item
 
-### Changes for a single entry
-**/api/integration/metadata-suggestions/<:suggestion-name>/entryValues/<:entry-id>/changes**  
+### Differences for a single entry
+**/api/integration/metadata-suggestions/<:suggestion-name>/entryValueDifferences/<:entry-id>**  
 
 Parameters:
 * workspaceitem: the current workspace item ID (mutually exclusive with workflowitem)
@@ -375,24 +385,86 @@ Parameters:
 
 It returns the suggested metadata changes from one entry to be applied to the given item
 
-sample for a live import source /api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436/changes
+sample for a live import source /api/integration/metadata-suggestions/orcid/entryValueDifferences/0000-0002-4271-0436?workspaceitem=123
 ```json
 {
-  "changes" : [
-    {
-      "op": "add",
-      "path": "/metadata/dc.identifier.orcid",
-      "value": [ { "value": "0000-0002-4271-0436" } ]
+  "differences" : {
+    "dc.identifier.orcid" : {
+      "currentvalues" : [],
+      "suggestions" : [
+        {
+          "operations": [ "add" ],
+          "newvalue": "0000-0002-4271-0436"
+        }
+      ]
     },
-    {
-      "op": "add",
-      "path": "/metadata/dc.identifier.uri/-",
-      "value": [ { "value": "https://orcid.org/0000-0002-4271-0436" } ]
+    "dc.identifier.uri" : {
+      "currentvalues" : [ "https://profiles.utsouthwestern.edu/profile/16780/dean-smith.html" ],
+      "suggestions" : [
+        {
+          "operations": [ "add", "replace/0" ],
+          "newvalue": "https://orcid.org/0000-0002-4271-0436"
+        }
+      ]
     }
-  ],
+  },
   "_links": {
     "self": {
-      "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436/changes"
+      "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValueDifferences/0000-0002-4271-0436?workspaceitem=123"
+    }
+  }
+}
+```
+
+sample for a live import source /api/integration/metadata-suggestions/pubmed/entryValueDifferences/31383667?workspaceitem=456
+```json
+{
+  "differences" : {
+    "dc.contributor.author" : {
+      "currentvalues" : [ "D. Pollard", "C. E. Wylie[virtual::1373]" ],
+      "suggestions" : [
+        {
+          "operations": [ "replace/0", "add" ],
+          "newvalue": "Pollard, D"
+        },
+        {
+          "operations": [ "namevariant/1", "add" ],
+          "newvalue": "Wylie, C E"
+        },
+        {
+          "operations": [ "add-relationship" ],
+          "newvalue": "Newton, J R",
+          "item": "1f8b3dd7-f5ae-4153-bf17-808d3a5379ac",
+          "relationship-type" : 1
+        }
+    ]
+    },
+    "dc.date.issued" : {
+      "currentvalues": [ "2019" ],
+      "suggestions": [
+        {
+          "operations": [ "replace/0" ],
+          "newvalue": "2019-09-23"
+        }
+      ]
+    },
+    "dc.subject" : {
+      "currentvalues" : [],
+      "suggestions": [
+        {
+          "operations": [ "add" ],
+          "newvalue": "DNA replication inhibitors"
+        },
+        {
+          "operations": [ "add" ],
+          "newvalue": "Mycobacterium"
+        }
+      ]
+    }
+  },
+  "_links": {
+    "self": {
+      "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/pubmed/entryValueDifferences/31383667?workspaceitem=456"
     }
   }
 }
@@ -408,16 +480,29 @@ The suggested changes are based on the current item:
 The live import can suggest metadata changes.
 The user should be given the choice to apply or ignore these metadata changes.
 
-The suggestions will be presented in a format compatible with the [Metadata Patch](metadata-patch.md)
-to allow the user-interface to easily apply the suggested changes.
+The suggestions will be presented in a format similar to the [Metadata Patch](metadata-patch.md)
+to allow the user-interface to easily display and apply the suggested changes.
+
+The suggestions include per metadata value:
+* The current values present in the item
+* Per suggested change, one or more operations (the first operation is assumed to be the preferred action)
+  * "add" is used to suggest adding the value at the end
+  * "replace/<:place>" is used to suggest replacing the value at <:place> with the new value
+  * "namevariant/<:place>" is used to suggest replacing the name variant of the relationship at <:place> with the new value
+  * "add-relationship" is used to suggest creating a new relationship
+* The new value for the suggested change
 
 The examples in each section below build on each other, assuming an initial metadata state of:
 
 ```json
 {
   "metadata": {
-    "dc.title": [
-      { "value": "Initial Title", "language": null, "authority": null, "confidence": -1 }
+    "dc.contributor.author": [
+      { "value": "D. Pollard", "language": null, "authority": null, "confidence": -1 },
+      { "value": "C. E. Wylie", "language": null, "authority": "virtual::1373", "confidence": 600 }
+    ],
+    "dc.date.issued": [
+      { "value": "2019", "language": null, "authority": null, "confidence": -1 }
     ]
   }
 }
@@ -430,44 +515,24 @@ If accepted, the user interface can perform a PATCH based on the suggested metad
 
 With the `add` operation, the live import suggests to add metadata new values.
 
-The `add` can also be used to effectively _replace_ all values for a given metadata key, by specifying
-an already-present key as the `path`, and an array of replacement values as the `value`.
-This use of the add operation to replace a list of values may be counter-intiutive, but it
-is done according to the [RFC section 4.1](https://tools.ietf.org/html/rfc6902#section-4.1)
-
-> If the target location specifies an object member that does exist, that member's value is replaced.
-
-Note:
-
-* According to the [JSON Patch specification](https://tools.ietf.org/html/rfc6902), to initialize the first
-  value for any array, the `add` operation must receive an array of values. Therefore, in the first operation
-  below, since it is not possible to add a single value to the not yet initialized `/metadata/dc.description`
-  array, we initialize it with an array with one value.
-* When values already exist for a metadata key, as in the second operation below, it is necessary to specify
-  the new value's position at the end of the `path` (`/0` means first position, `/-` means last).
-* When creating new metadata values, if unspecified, the `language` and `authority` properties
-  default to `null`, and `confidence` defaults to `-1`.
-
 Example response, suggestion the addition of three values:
 
 ```json
-[
-  {
-    "op": "add",
-    "path": "/metadata/dc.description",
-    "value": [ { "value": "Some description" } ]
-  },
-  {
-    "op": "add",
-    "path": "/metadata/dc.title/0",
-    "value": { "value": "Zeroth Title" }
-  },
-  {
-    "op": "add",
-    "path": "/metadata/dc.title/-",
-    "value": { "value": "Final Title", "language": "en_US" }
+{
+  "dc.subject" : {
+    "currentvalues" : [],
+    "suggestions": [
+      {
+        "operations": [ "add" ],
+        "newvalue": "DNA replication inhibitors"
+      },
+      {
+        "operations": [ "add" ],
+        "newvalue": "Mycobacterium"
+      }
+    ]
   }
-]
+}
 ```
 
 If this patch is applied hereafter, the new metadata state is:
@@ -475,13 +540,16 @@ If this patch is applied hereafter, the new metadata state is:
 ```json
 {
   "metadata": {
-    "dc.description": [
-      { "value": "Some description", "language": null, "authority": null, "confidence": -1 }
+    "dc.contributor.author": [
+      { "value": "D. Pollard", "language": null, "authority": null, "confidence": -1 },
+      { "value": "C. E. Wylie", "language": null, "authority": "virtual::1373", "confidence": 600 }
     ],
-    "dc.title": [
-      { "value": "Zeroth Title", "language": null, "authority": null, "confidence": -1 },
-      { "value": "Initial Title", "language": null, "authority": null, "confidence": -1 },
-      { "value": "Final Title", "language": "en_US", "authority": null, "confidence": -1 }
+    "dc.date.issued": [
+      { "value": "2019", "language": null, "authority": null, "confidence": -1 }
+    ],
+    "dc.subject": [
+      { "value": "DNA replication inhibitors", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Mycobacterium", "language": null, "authority": null, "confidence": -1 }
     ]
   }
 }
@@ -489,24 +557,23 @@ If this patch is applied hereafter, the new metadata state is:
 
 ### Replacing metadata
 
-With `replace`, the live import suggests to overwrite any of the following within a single operation
-of a PATCH request:
+With `replace`, the live import suggests to overwrite a single existing metadata value:
+* `replace/<:place>` is used to suggest replacing the value at <:place> with the new value
 
-* The entire set of all object metadata (`path="/metadata"`)
-* All metadata values for an existing key (e.g. `path="/metadata/dc.title"`)
-* A single existing metadata value (e.g. `path="/metadata/dc.title/0"`)
-* A single property of an existing value (e.g. `path="/metadata/dc.title/0/language"`)
-
-Example response, replacing the `value` and `language` of the first `dc.title`:
+Example response, replacing the the first `dc.date.issued`:
 
 ```json
-[
-  {
-    "op": "replace",
-    "path": "/metadata/dc.title/0",
-    "value": { "value": "最後のタイトル", "language": "ja_JP" }
-  }
-]
+{
+    "dc.date.issued" : {
+      "currentvalues": [ "2019" ],
+      "suggestions": [
+        {
+          "operations": [ "replace/0" ],
+          "newvalue": "2019-09-23"
+        }
+      ]
+    }
+}
 ```
 
 If this patch is applied hereafter, the new metadata state is:
@@ -514,10 +581,101 @@ If this patch is applied hereafter, the new metadata state is:
 ```json
 {
   "metadata": {
-    "dc.title": [
-      { "value": "最後のタイトル", "language": "ja_JP", "authority": null, "confidence": -1 },
-      { "value": "Initial Title", "language": null, "authority": null, "confidence": -1 },
-      { "value": "Final Title", "language": "en_US", "authority": null, "confidence": -1 }
+    "dc.contributor.author": [
+      { "value": "D. Pollard", "language": null, "authority": null, "confidence": -1 },
+      { "value": "C. E. Wylie", "language": null, "authority": "virtual::1373", "confidence": 600 }
+    ],
+    "dc.date.issued": [
+      { "value": "2019-09-23", "language": null, "authority": null, "confidence": -1 }
+    ],
+    "dc.subject": [
+      { "value": "DNA replication inhibitors", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Mycobacterium", "language": null, "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```
+
+### Replacing name variants
+
+With `namevariant`, the live import suggests to overwrite a single name variant:
+* `namevariant/<:place>` is used to suggest replacing the name variant of the relationship at <:place> with the new value
+
+Example response, replacing the the second `dc.contributor.author` name variant:
+
+```json
+{
+    "dc.contributor.author" : {
+      "currentvalues" : [ "D. Pollard", "C. E. Wylie[virtual::1373]" ],
+      "suggestions" : [
+        {
+          "operations": [ "namevariant/1", "add" ],
+          "newvalue": "Wylie, C E"
+        }
+      ]
+    }
+}
+```
+
+If this patch is applied hereafter, the new metadata state is:
+
+```json
+{
+  "metadata": {
+    "dc.contributor.author": [
+      { "value": "D. Pollard", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Wylie, C E", "language": null, "authority": "virtual::1373", "confidence": 600 }
+    ],
+    "dc.date.issued": [
+      { "value": "2019-09-23", "language": null, "authority": null, "confidence": -1 }
+    ],
+    "dc.subject": [
+      { "value": "DNA replication inhibitors", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Mycobacterium", "language": null, "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```
+
+### Adding relationships
+
+With `add-relationship`, the live import suggests to add a new relationship
+* `add-relationship` is used to suggest creating a new relationship
+
+Example response, adding a `dc.contributor.author` relationship:
+
+```json
+{
+    "dc.contributor.author" : {
+      "currentvalues" : [ "D. Pollard", "C. E. Wylie[virtual::1373]" ],
+      "suggestions" : [
+        {
+          "operations": [ "add-relationship" ],
+          "newvalue": "Newton, J R",
+          "item": "1f8b3dd7-f5ae-4153-bf17-808d3a5379ac",
+          "relationship-type" : 1
+        }
+      ]
+    }
+}
+```
+
+If this patch is applied hereafter, the new metadata state is:
+
+```json
+{
+  "metadata": {
+    "dc.contributor.author": [
+      { "value": "D. Pollard", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Wylie, C E", "language": null, "authority": "virtual::1373", "confidence": 600 },
+      { "value": "Newton, J R", "language": null, "authority": "virtual::1375", "confidence": 600 }
+    ],
+    "dc.date.issued": [
+      { "value": "2019-09-23", "language": null, "authority": null, "confidence": -1 }
+    ],
+    "dc.subject": [
+      { "value": "DNA replication inhibitors", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Mycobacterium", "language": null, "authority": null, "confidence": -1 }
     ]
   }
 }

--- a/metadata-suggestions.md
+++ b/metadata-suggestions.md
@@ -289,10 +289,6 @@ The differences are explained below, and won't be embedded in this endpoint.
 ### Single entry
 **/api/integration/metadata-suggestions/<:suggestion-name>/entryValues/<:entry-id>**  
 
-Parameters:
-* workspaceitem: the current workspace item ID (mutually exclusive with workflowitem)
-* workflowitem: the current workflow item ID (mutually exclusive with workspaceitem)
-
 It returns the data from one entry in a live import source
 
 sample for a live import source /api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436
@@ -348,38 +344,16 @@ sample for a live import source /api/integration/metadata-suggestions/orcid/entr
     "differences": {
       "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValueDifferences/0000-0002-4271-0436"
     }
-  },
-  "_embedded" : {
-     "differences" : {
-         "dc.identifier.orcid" : {
-           "currentvalues" : [],
-           "suggestions" : [
-             {
-               "operations": [ "add/metadata/dc.identifier.orcid/-" ],
-               "newvalue": "0000-0002-4271-0436"
-             }
-           ]
-         },
-         "dc.identifier.uri" : {
-           "currentvalues" : [ "https://profiles.utsouthwestern.edu/profile/16780/dean-smith.html" ],
-           "suggestions" : [
-             {
-               "operations": [ "add/metadata/dc.identifier.uri/-", "replace/metadata/dc.identifier.uri/0" ],
-               "newvalue": "https://orcid.org/0000-0002-4271-0436"
-             }
-           ]
-         }
-     }
   }
 }
 ```
 
-The differences embedded are the suggested metadata changes to be applied to the given item
+The differences are explained below
 
 ### Differences for a single entry
 **/api/integration/metadata-suggestions/<:suggestion-name>/entryValueDifferences/<:entry-id>**  
 
-Parameters:
+Parameters (workspaceitem or workflowitem is mandatory):
 * workspaceitem: the current workspace item ID (mutually exclusive with workflowitem)
 * workflowitem: the current workflow item ID (mutually exclusive with workspaceitem)
 
@@ -473,6 +447,7 @@ sample for a live import source /api/integration/metadata-suggestions/pubmed/ent
 The suggested changes are based on the current item:
 * It takes the current metadata of the item into account (don't suggest to add a title which is already present)
 * It takes the submission forms into account (don't suggest to change metadata fields which are not editable based on input forms, only one value for a non-repeatable field)
+* It suggests operations to apply to the item. The first operation is considered the most relevant by REST (but the user can choose another operation)
 
 ## Changes suggested from the live import
 ### Introduction

--- a/metadata-suggestions.md
+++ b/metadata-suggestions.md
@@ -1,0 +1,528 @@
+# Metadata suggestions from live import
+[Back to the index](README.md)
+
+**Contents:**
+
+- [Introduction](#introduction)
+- [Main Endpoint](#main-endpoint)
+- [Single suggestion endpoint](#single-suggestion-endpoint)
+- [Linked entities](#linked-entities)
+	- [External source entries](#external-source-entries)
+	- [Single entry](#single-entry)
+	- [Changes for a single entry](#changes-for-a-single-entry)
+- [Changes suggested from the external source](#changes-suggested-from-the-external-source)
+	- [Introduction](#introduction)
+	- [Adding metadata](#adding-metadata)
+	- [Replacing metadata](#replacing-metadata)
+
+## Introduction
+
+This contract allows for suggesting metadata changes to an in-submission or in-workflow item.
+The user can choose an external source to use for suggesting the metadata (e.g. PubMed for a medical publication, ORCID for an author, a RIS file for uploaded metadata).
+The external source will suggest matches, and will suggest metadata changes if the match is accepted by the user.
+A full metadata description of the data from the external source is displayed in combination to the suggested changes to the current item.
+
+TODO:
+* start a new submission based on a external source record
+
+## Main Endpoint
+**/api/integration/metadata-suggestions**
+
+Provide access to the configured external sources which can suggest metadata.
+It returns the list of existent external sources.
+
+Parameters (or should this be retrieved from the submission forms?):
+* workspaceitem
+* workflowitem
+
+The list can differ per item.
+A Person item can be limited to sources containing people such as orcid.
+A Publication item can be limited to sources containing publications such as PubMed
+
+Example:
+```json
+{
+  "_embedded": {
+    "metadata-suggestions": [
+      {
+        "id": "pubmed",
+        "name": "pubmed",
+        "type": "metadataSuggestion",
+        "query-based": "true",
+        "file-based": "false",
+        "metadata-based": "true",
+        "_links": {
+          "entries": {
+            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/pubmed/entries"
+          },
+          "self": {
+            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/pubmed"
+          }
+        }
+      },
+      {
+        "id": "orcid",
+        "name": "orcid",
+        "type": "metadataSuggestion",
+        "query-based": "true",
+        "file-based": "false",
+        "metadata-based": "true",
+        "_links": {
+          "entries": {
+            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entries"
+          },
+          "self": {
+            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid"
+          }
+        }
+      },
+      {
+        "id": "ciencia",
+        "name": "ciencia",
+        "type": "metadataSuggestion",
+        "query-based": "true",
+        "file-based": "false",
+        "metadata-based": "true",
+        "_links": {
+          "entries": {
+            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/ciencia/entries"
+          },
+          "self": {
+            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/ciencia"
+          }
+        }
+      },
+      {
+        "id": "ris_data_loader",
+        "name": "ris_data_loader",
+        "type": "metadataSuggestion",
+        "query-based": "false",
+        "file-based": "true",
+        "metadata-based": "false",
+        "_links": {
+          "entries": {
+            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/ris_data_loader/entries"
+          },
+          "self": {
+            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/ris_data_loader"
+          }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions"
+    }
+  },
+  "page": {
+    "size": 20,
+    "totalElements": 3,
+    "totalPages": 1,
+    "number": 0
+  }
+}
+```
+
+## Single suggestion endpoint
+**/api/integration/metadata-suggestions/<:suggestion-name>**
+
+Provide detailed information about a specific external source. The JSON response document is as follow
+```json
+{
+    "id": "pubmed",
+    "name": "pubmed",
+    "type": "metadataSuggestion",
+    "query-based": "true",
+    "file-based": "false",
+    "metadata-based": "true",
+    "_links": {
+      "entries": {
+        "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/pubmed/entries"
+      },
+      "self": {
+        "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/pubmed"
+      }
+    }
+}
+```
+
+Properties:
+* query-based: if the external source uses a query to suggest information to import
+* file-based: if the external source uses a file to suggest information to import
+* metadata-based: if the external source uses the current item metadata to suggest information to import
+
+Exposed links:
+* entries: the list of values managed by the external source
+
+## Linked entities
+### External source entries
+**/api/integration/metadata-suggestions/<:suggestion-name>/entries**
+**/api/submission/workflowitems/<:id>/metadata-suggestions/<:suggestion-name>/entries**
+
+It returns the filtered entries managed by the external source, see below
+
+The supported parameters are:
+* page, size [see pagination](README.md#Pagination) if supported by the external source
+* query: the terms, keywords or prefix to search. Applicable for sources where "query-based" is true
+* bitstream: the bitstream ID to process. Applicable for sources where "file-based" is true
+* use-metadata: enable metadata based search (true or false, defaults to false). Applicable for sources where "metadata-based" is true
+* workspaceitem: the current workspace item ID (mutually exclusive with workflowitem)
+* workflowitem: the current workflow item ID (mutually exclusive with workspaceitem)
+
+It returns the entries in the external source matching the query, bitstream or item metadata
+
+sample for an external source /api/integration/metadata-suggestions/orcid/entries?query=Smith&size=2
+```json
+{
+  "_embedded": {
+    "metadataSuggestionEntries": [
+      {
+        "id": "0000-0002-4271-0436",
+        "display": "Smith, Dean",
+        "value": "Smith, Dean",
+        "metadata": {
+            "dc.identifier.orcid": [
+              {
+                "value": "0000-0002-4271-0436",
+                "language": null,
+                "authority": null,
+                "confidence": -1,
+                "place": -1
+              }
+            ],
+            "dc.identifier.uri": [
+              {
+                "value": "https://orcid.org/0000-0002-4271-0436",
+                "language": null,
+                "authority": null,
+                "confidence": -1,
+                "place": -1
+              }
+            ],
+            "person.familyName": [
+              {
+                "value": "Smith",
+                "language": null,
+                "authority": null,
+                "confidence": -1,
+                "place": -1
+              }
+            ],
+            "person.givenName": [
+              {
+                "value": "Dean",
+                "language": null,
+                "authority": null,
+                "confidence": -1,
+                "place": -1
+              }
+            ]
+        },
+        "type": "metadataSuggestionEntry",
+        "_links": {
+          "self": {
+            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436"
+          },
+          "changes": {
+            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436/changes"
+          }
+        }
+      },
+      {
+        "id": "0000-0003-3681-2038",
+        "display": "Smith, Charles",
+        "value": "Smith, Charles",
+        "metadata": {
+            "dc.identifier.orcid": [
+              {
+                "value": "0000-0003-3681-2038",
+                "language": null,
+                "authority": null,
+                "confidence": -1,
+                "place": -1
+              }
+            ],
+            "dc.identifier.uri": [
+              {
+                "value": "https://orcid.org/0000-0003-3681-2038",
+                "language": null,
+                "authority": null,
+                "confidence": -1,
+                "place": -1
+              }
+            ],
+            "person.familyName": [
+              {
+                "value": "Smith",
+                "language": null,
+                "authority": null,
+                "confidence": -1,
+                "place": -1
+              }
+            ],
+            "person.givenName": [
+              {
+                "value": "Charles",
+                "language": null,
+                "authority": null,
+                "confidence": -1,
+                "place": -1
+              }
+            ]
+        },
+        "type": "metadataSuggestionEntry",
+        "_links": {
+          "self": {
+            "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0003-3681-2038"
+          },
+         "changes": {
+           "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0003-3681-2038/changes"
+         }
+        }
+      }
+    ]
+  }
+}
+```
+
+The changes are explained below, and won't be embedded in this endpoint.
+
+### Single entry
+**/api/integration/metadata-suggestions/<:suggestion-name>/entryValues/<:entry-id>**  
+
+Parameters:
+* workspaceitem: the current workspace item ID (mutually exclusive with workflowitem)
+* workflowitem: the current workflow item ID (mutually exclusive with workspaceitem)
+
+It returns the data from one entry in an external source
+
+sample for an external source /api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436
+```json
+{
+  "id": "0000-0002-4271-0436",
+  "display": "Smith, Dean",
+  "value": "Smith, Dean",
+  "type": "metadataSuggestionEntry",
+  "metadataSuggestion": "orcid",
+  "metadata": {
+    "dc.identifier.orcid": [
+      {
+        "value": "0000-0002-4271-0436",
+        "language": null,
+        "authority": null,
+        "confidence": 0,
+        "place": -1
+      }
+    ],
+    "dc.identifier.uri": [
+      {
+        "value": "https://orcid.org/0000-0002-4271-0436",
+        "language": null,
+        "authority": null,
+        "confidence": 0,
+        "place": -1
+      }
+    ],
+    "person.familyName": [
+      {
+        "value": "Smith",
+        "language": null,
+        "authority": null,
+        "confidence": 0,
+        "place": -1
+      }
+    ],
+    "person.givenName": [
+      {
+        "value": "Dean",
+        "language": null,
+        "authority": null,
+        "confidence": 0,
+        "place": -1
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436"
+    },
+    "changes": {
+      "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436/changes"
+    }
+  },
+  "_embedded" : {
+     "changes" : [
+      {
+        "op": "add",
+        "path": "/metadata/dc.identifier.orcid",
+        "value": [ { "value": "0000-0002-4271-0436" } ]
+      },
+      {
+        "op": "add",
+        "path": "/metadata/dc.identifier.uri/-",
+        "value": [ { "value": "https://orcid.org/0000-0002-4271-0436" } ]
+      }
+     ]
+  }
+}
+```
+
+The changes embedded are the suggested metadata changes to be applied to the given item
+
+### Changes for a single entry
+**/api/integration/metadata-suggestions/<:suggestion-name>/entryValues/<:entry-id>/changes**  
+
+Parameters:
+* workspaceitem: the current workspace item ID (mutually exclusive with workflowitem)
+* workflowitem: the current workflow item ID (mutually exclusive with workspaceitem)
+
+It returns the suggested metadata changes from one entry to be applied to the given item
+
+sample for an external source /api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436/changes
+```json
+{
+  "changes" : [
+    {
+      "op": "add",
+      "path": "/metadata/dc.identifier.orcid",
+      "value": [ { "value": "0000-0002-4271-0436" } ]
+    },
+    {
+      "op": "add",
+      "path": "/metadata/dc.identifier.uri/-",
+      "value": [ { "value": "https://orcid.org/0000-0002-4271-0436" } ]
+    }
+  ],
+  "_links": {
+    "self": {
+      "href": "https://dspace7-internal.atmire.com/server/api/integration/metadata-suggestions/orcid/entryValues/0000-0002-4271-0436/changes"
+    }
+  }
+}
+```
+
+The suggested changes are based on the current item:
+* It takes the current metadata of the item into account (don't suggest to add a title which is already present)
+* It takes the submission forms into account (don't suggest to change metadata fields which are not editable based on input forms, only one value for a non-repeatable field)
+
+## Changes suggested from the external source
+### Introduction
+
+The live import can suggest metadata changes.
+The user should be given the choice to apply or ignore these metadata changes.
+
+The suggestions will be presented in a format compatible with the [Metadata Patch](metadata-patch.md)
+to allow the user-interface to easily apply the suggested changes.
+
+The examples in each section below build on each other, assuming an initial metadata state of:
+
+```json
+{
+  "metadata": {
+    "dc.title": [
+      { "value": "Initial Title", "language": null, "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```
+
+The user interface can display the suggested metadata changes, and request the user to accept or reject the changes.
+If accepted, the user interface can perform a PATCH based on the suggested metadata changes to apply the suggestions.
+
+### Adding metadata
+
+With the `add` operation, the live import suggests to add metadata new values.
+
+The `add` can also be used to effectively _replace_ all values for a given metadata key, by specifying
+an already-present key as the `path`, and an array of replacement values as the `value`.
+This use of the add operation to replace a list of values may be counter-intiutive, but it
+is done according to the [RFC section 4.1](https://tools.ietf.org/html/rfc6902#section-4.1)
+
+> If the target location specifies an object member that does exist, that member's value is replaced.
+
+Note:
+
+* According to the [JSON Patch specification](https://tools.ietf.org/html/rfc6902), to initialize the first
+  value for any array, the `add` operation must receive an array of values. Therefore, in the first operation
+  below, since it is not possible to add a single value to the not yet initialized `/metadata/dc.description`
+  array, we initialize it with an array with one value.
+* When values already exist for a metadata key, as in the second operation below, it is necessary to specify
+  the new value's position at the end of the `path` (`/0` means first position, `/-` means last).
+* When creating new metadata values, if unspecified, the `language` and `authority` properties
+  default to `null`, and `confidence` defaults to `-1`.
+
+Example response, suggestion the addition of three values:
+
+```json
+[
+  {
+    "op": "add",
+    "path": "/metadata/dc.description",
+    "value": [ { "value": "Some description" } ]
+  },
+  {
+    "op": "add",
+    "path": "/metadata/dc.title/0",
+    "value": { "value": "Zeroth Title" }
+  },
+  {
+    "op": "add",
+    "path": "/metadata/dc.title/-",
+    "value": { "value": "Final Title", "language": "en_US" }
+  }
+]
+```
+
+If this patch is applied hereafter, the new metadata state is:
+
+```json
+{
+  "metadata": {
+    "dc.description": [
+      { "value": "Some description", "language": null, "authority": null, "confidence": -1 }
+    ],
+    "dc.title": [
+      { "value": "Zeroth Title", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Initial Title", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Final Title", "language": "en_US", "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```
+
+### Replacing metadata
+
+With `replace`, the live import suggests to overwrite any of the following within a single operation
+of a PATCH request:
+
+* The entire set of all object metadata (`path="/metadata"`)
+* All metadata values for an existing key (e.g. `path="/metadata/dc.title"`)
+* A single existing metadata value (e.g. `path="/metadata/dc.title/0"`)
+* A single property of an existing value (e.g. `path="/metadata/dc.title/0/language"`)
+
+Example response, replacing the `value` and `language` of the first `dc.title`:
+
+```json
+[
+  {
+    "op": "replace",
+    "path": "/metadata/dc.title/0",
+    "value": { "value": "最後のタイトル", "language": "ja_JP" }
+  }
+]
+```
+
+If this patch is applied hereafter, the new metadata state is:
+
+```json
+{
+  "metadata": {
+    "dc.title": [
+      { "value": "最後のタイトル", "language": "ja_JP", "authority": null, "confidence": -1 },
+      { "value": "Initial Title", "language": null, "authority": null, "confidence": -1 },
+      { "value": "Final Title", "language": "en_US", "authority": null, "confidence": -1 }
+    ]
+  }
+}
+```

--- a/metadata-suggestions.md
+++ b/metadata-suggestions.md
@@ -22,9 +22,6 @@ The user can choose an external source to use for suggesting the metadata (e.g. 
 The external source will suggest matches, and will suggest metadata changes if the match is accepted by the user.
 A full metadata description of the data from the external source is displayed in combination to the suggested changes to the current item.
 
-TODO:
-* start a new submission based on a external source record
-
 ## Main Endpoint
 **/api/integration/metadata-suggestions**
 

--- a/metadata-suggestions.md
+++ b/metadata-suggestions.md
@@ -355,7 +355,7 @@ sample for a live import source /api/integration/metadata-suggestions/orcid/entr
            "currentvalues" : [],
            "suggestions" : [
              {
-               "operations": [ "add" ],
+               "operations": [ "add/metadata/dc.identifier.orcid/-" ],
                "newvalue": "0000-0002-4271-0436"
              }
            ]
@@ -364,7 +364,7 @@ sample for a live import source /api/integration/metadata-suggestions/orcid/entr
            "currentvalues" : [ "https://profiles.utsouthwestern.edu/profile/16780/dean-smith.html" ],
            "suggestions" : [
              {
-               "operations": [ "add", "replace/0" ],
+               "operations": [ "add/metadata/dc.identifier.uri/-", "replace/metadata/dc.identifier.uri/0" ],
                "newvalue": "https://orcid.org/0000-0002-4271-0436"
              }
            ]
@@ -393,7 +393,7 @@ sample for a live import source /api/integration/metadata-suggestions/orcid/entr
       "currentvalues" : [],
       "suggestions" : [
         {
-          "operations": [ "add" ],
+          "operations": [ "add/metadata/dc.identifier.orcid/-" ],
           "newvalue": "0000-0002-4271-0436"
         }
       ]
@@ -402,7 +402,7 @@ sample for a live import source /api/integration/metadata-suggestions/orcid/entr
       "currentvalues" : [ "https://profiles.utsouthwestern.edu/profile/16780/dean-smith.html" ],
       "suggestions" : [
         {
-          "operations": [ "add", "replace/0" ],
+          "operations": [ "add/metadata/dc.identifier.uri/-", "replace/metadata/dc.identifier.uri/0" ],
           "newvalue": "https://orcid.org/0000-0002-4271-0436"
         }
       ]
@@ -424,15 +424,15 @@ sample for a live import source /api/integration/metadata-suggestions/pubmed/ent
       "currentvalues" : [ "D. Pollard", "C. E. Wylie[virtual::1373]" ],
       "suggestions" : [
         {
-          "operations": [ "replace/0", "add" ],
+          "operations": [ "replace/metadata/dc.contributor.author/0", "add/metadata/dc.contributor.author/-" ],
           "newvalue": "Pollard, D"
         },
         {
-          "operations": [ "namevariant/1", "add" ],
+          "operations": [ "namevariant/metadata/dc.contributor.author/1", "add/metadata/dc.contributor.author/-" ],
           "newvalue": "Wylie, C E"
         },
         {
-          "operations": [ "add-relationship" ],
+          "operations": [ "add-relationship/metadata/dc.contributor.author/-" ],
           "newvalue": "Newton, J R",
           "item": "1f8b3dd7-f5ae-4153-bf17-808d3a5379ac",
           "relationship-type" : 1
@@ -443,7 +443,7 @@ sample for a live import source /api/integration/metadata-suggestions/pubmed/ent
       "currentvalues": [ "2019" ],
       "suggestions": [
         {
-          "operations": [ "replace/0" ],
+          "operations": [ "replace/metadata/dc.date.issued/0" ],
           "newvalue": "2019-09-23"
         }
       ]
@@ -452,11 +452,11 @@ sample for a live import source /api/integration/metadata-suggestions/pubmed/ent
       "currentvalues" : [],
       "suggestions": [
         {
-          "operations": [ "add" ],
+          "operations": [ "add/metadata/dc.subject/-" ],
           "newvalue": "DNA replication inhibitors"
         },
         {
-          "operations": [ "add" ],
+          "operations": [ "add/metadata/dc.subject/-" ],
           "newvalue": "Mycobacterium"
         }
       ]
@@ -523,11 +523,11 @@ Example response, suggestion the addition of three values:
     "currentvalues" : [],
     "suggestions": [
       {
-        "operations": [ "add" ],
+        "operations": [ "add/metadata/dc.subject/-" ],
         "newvalue": "DNA replication inhibitors"
       },
       {
-        "operations": [ "add" ],
+        "operations": [ "add/metadata/dc.subject/-" ],
         "newvalue": "Mycobacterium"
       }
     ]
@@ -568,7 +568,7 @@ Example response, replacing the the first `dc.date.issued`:
       "currentvalues": [ "2019" ],
       "suggestions": [
         {
-          "operations": [ "replace/0" ],
+          "operations": [ "replace/metadata/dc.date.issued/0" ],
           "newvalue": "2019-09-23"
         }
       ]
@@ -609,7 +609,7 @@ Example response, replacing the the second `dc.contributor.author` name variant:
       "currentvalues" : [ "D. Pollard", "C. E. Wylie[virtual::1373]" ],
       "suggestions" : [
         {
-          "operations": [ "namevariant/1", "add" ],
+          "operations": [ "namevariant/metadata/dc.contributor.author/1", "add/metadata/dc.contributor.author/-" ],
           "newvalue": "Wylie, C E"
         }
       ]
@@ -650,7 +650,7 @@ Example response, adding a `dc.contributor.author` relationship:
       "currentvalues" : [ "D. Pollard", "C. E. Wylie[virtual::1373]" ],
       "suggestions" : [
         {
-          "operations": [ "add-relationship" ],
+          "operations": [ "add-relationship/metadata/dc.contributor.author/-" ],
           "newvalue": "Newton, J R",
           "item": "1f8b3dd7-f5ae-4153-bf17-808d3a5379ac",
           "relationship-type" : 1

--- a/metadata-suggestions.md
+++ b/metadata-suggestions.md
@@ -592,7 +592,7 @@ Example response, replacing the the second `dc.contributor.author` name variant:
 }
 ```
 
-The above example includes two possible operations: an option to replace the namevariant, and an option to add the newvalue as an additional author.
+The above example includes two possible operations: an option to replace the `namevariant`, and an option to add the `newvalue` as an additional author.
 Assuming the client chooses the first operation (replace the namevariant), the new metadata state is:
 
 ```json

--- a/workspaceitems.md
+++ b/workspaceitems.md
@@ -125,15 +125,16 @@ It returns the workspaceitem created by the specified submitter
 Multipart POST request will typically result in the creation of a new file in the section identified by the name of the variable used for the upload (uploads is the default name of the user uploaded content). The process will be managed by the implementation bind with the identified section.
 If succeed a 201 code will be returned and the new state of the workspaceitem serialized in the body.
 
+An attribute to define the owning collection can be included. If omitted, the first collection the user can submit to will be used
+
 The Multipart POST can include a uri-list containing:
-* the owning collection to be used
 * The [external entry value](external-authority-sources.md) whose metadata should be imported
 
 An example curl call:
 ```
- curl -i -X POST https://dspace7.4science.it/dspace-spring-rest/api/submission/workspaceitems \
+ curl -i -X POST https://dspace7.4science.it/dspace-spring-rest/api/submission/workspaceitems?owningCollection=1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb \
  -H "Content-Type:text/uri-list" \
- --data "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb \n https://dspace7.4science.it/dspace-spring-rest/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
+ --data "https://dspace7.4science.it/dspace-spring-rest/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
 ```
 
 No confirmation, user has confirmed they want this record, and the previous state of the item is empty

--- a/workspaceitems.md
+++ b/workspaceitems.md
@@ -123,4 +123,22 @@ It returns the workspaceitem created by the specified submitter
 
 ## Multipart POST Method
 Multipart POST request will typically result in the creation of a new file in the section identified by the name of the variable used for the upload (uploads is the default name of the user uploaded content). The process will be managed by the implementation bind with the identified section.
-If succeed a 201 code will be returned and the new state of the workspaceitem serialized in the body.   
+If succeed a 201 code will be returned and the new state of the workspaceitem serialized in the body.
+
+The Multipart POST can include a uri-list containing:
+* the owning collection to be used
+* The [external entry value](external-authority-sources.md) whose metadata should be imported
+
+An example curl call:
+```
+ curl -i -X POST https://dspace7.4science.it/dspace-spring-rest/api/submission/workspaceitems \
+ -H "Content-Type:text/uri-list" \
+ --data "https://dspace7.4science.it/dspace-spring-rest/api/core/collections/1c11f3f1-ba1f-4f36-908a-3f1ea9a557eb \n https://dspace7.4science.it/dspace-spring-rest/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
+```
+
+No confirmation, user has confirmed they want this record, and the previous state of the item is empty
+
+If an external entry value is included, the metadata from this external source should be imported automatically.  
+There's no need for a preview of the expected changes similar to the [Metadata Suggestions](metadata-suggestions.md) functionality because
+* The user has already confirmed they want to import this particular record
+* This is a new submission, it starts from an empty item


### PR DESCRIPTION
https://jira.duraspace.org/browse/DS-4281
This Rest Contract will introduce the live import from https://wiki.duraspace.org/dsdoc6x/using-dspace/ingesting-content-and-metadata/submission-user-interface/2016-framework-for-live-import-from-external-sources
This will allow the user to choose an external source to import from, retrieve suggestions, and apply the metadata changes once the user has confirmed the suggested changes are applicable.

This Rest Contract is related to https://github.com/DSpace/Rest7Contract/pull/74

It ensures a submission can be started based on an external source.
This uses a POST on the /api/submission/workspaceitems, with a URI-list (with the collection and external source).
The item metadata is imported in this case