### PR TITLE
adding entry HAL Link at entryValues level

### DIFF
--- a/external-authority-sources.md
+++ b/external-authority-sources.md
@@ -150,7 +150,7 @@ sample for an external source /server/api/integration/externalsources/orcid/entr
           "authority": {
             "href": "https://dspace7.4science.cloud/server/api/integration/authorities/authors/entryValues/d4b5ca88-9d6d-4a87-b905-fef0f8cae26c"
           },
-          "entry": {
+          "parent": {
             "href": "https://dspace7.4science.cloud/server/api/integration/externalsources/orcid"
           },
           "self": {
@@ -205,7 +205,7 @@ sample for an external source /server/api/integration/externalsources/orcid/entr
           "entity": {
             "href": "https://dspace7.4science.cloud/server/api/core/item/6fd90bf5-b84f-47b3-aaec-a55bde3a2a5a"
           },
-          "entry": {
+          "parent": {
             "href": "https://dspace7.4science.cloud/server/api/integration/externalsources/orcid"
           },          
           "self": {
@@ -273,7 +273,7 @@ sample for an external source /api/integration/externalsources/orcid/entryValues
     "entity": {
       "href": "https://dspace7.4science.cloud/server/api/core/item/00167e74-c027-4984-8564-85c3fe513d45"
     },
-    "entry": {
+    "parent": {
       "href": "https://dspace7.4science.cloud/server/api/integration/externalsources/orcid"
     },    
     "self": {

--- a/external-authority-sources.md
+++ b/external-authority-sources.md
@@ -150,6 +150,9 @@ sample for an external source /server/api/integration/externalsources/orcid/entr
           "authority": {
             "href": "https://dspace7.4science.cloud/server/api/integration/authorities/authors/entryValues/d4b5ca88-9d6d-4a87-b905-fef0f8cae26c"
           },
+          "entry": {
+            "href": "https://dspace7.4science.cloud/server/api/integration/externalsources/orcid"
+          },
           "self": {
             "href": "https://dspace7.4science.cloud/server/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
           }
@@ -202,6 +205,9 @@ sample for an external source /server/api/integration/externalsources/orcid/entr
           "entity": {
             "href": "https://dspace7.4science.cloud/server/api/core/item/6fd90bf5-b84f-47b3-aaec-a55bde3a2a5a"
           },
+          "entry": {
+            "href": "https://dspace7.4science.cloud/server/api/integration/externalsources/orcid"
+          },          
           "self": {
             "href": "https://dspace7.4science.cloud/server/api/integration/externalsources/orcid/entryValues/0000-0003-3681-2038"
           }
@@ -267,6 +273,9 @@ sample for an external source /api/integration/externalsources/orcid/entryValues
     "entity": {
       "href": "https://dspace7.4science.cloud/server/api/core/item/00167e74-c027-4984-8564-85c3fe513d45"
     },
+    "entry": {
+      "href": "https://dspace7.4science.cloud/server/api/integration/externalsources/orcid"
+    },    
     "self": {
       "href": "https://dspace7.4science.cloud/server/api/integration/externalsources/orcid/entryValues/0000-0002-4271-0436"
     }


### PR DESCRIPTION
It might be useful to include the reference for the entry (parent) at entryValues HAL links:

```
 "_links": {
    "entry": {
       "href": "https://localhost/server/api/integration/externalsources/orcidV2"
    },
    "self": {
      "href": "https://localhost/server/api/integration/externalsources/orcidV2/entryValues/0000-0002-3503-4812"
    }
  }
```