### PR TITLE
Workflow step definitions

### DIFF
--- a/endpoints.md
+++ b/endpoints.md
@@ -24,6 +24,8 @@
 * [/api/config/submissionsections](submissionsections.md)
 * [/api/config/submissionforms](submissionforms.md)
 * [/api/config/submissionuploads](submissionuploads.md)
+* [/api/config/workflowdefinitions](workflowdefinitions.md)
+* [/api/config/workflowsteps](workflowsteps.md)
 * [/api/discover/browses](browses.md)
 * [/api/discover/search](search-endpoint.md)
 * [/api/submission/workspaceitems](workspaceitems.md)

--- a/workflowdefinitions.md
+++ b/workflowdefinitions.md
@@ -1,0 +1,46 @@
+# Workflow Definitions Endpoints
+[Back to the list of all defined endpoints](endpoints.md)
+
+A workflow definition is defined globally or per collection.  
+It defines the list of steps to use in the workflow per collection, and the default steps.
+
+All endpoints mentioned here require authentication
+
+## Main Endpoint
+**/api/config/workflowdefinitions**   
+
+Provide access to the configured workflow definitions. It returns the list of existent workflow-definitions.
+
+## Single Workflow Definition
+**/api/config/workflowdefinitions/<:definition-name>**
+
+Provide detailed information about a specific workflow definition. The JSON response document is as follow
+```json
+{
+  "name": "default",
+  "isDefault": true,
+  "type": "workflow-definition"
+}
+```
+
+Exposed links:
+* collections: list of collections that explicitly use such workflow-definition
+* steps: list of workflow steps included in this definition
+
+### Search methods
+#### findByCollection
+**/api/config/workflowdefinitions/search/findByCollection?uuid=<:collection-uuid>**
+
+It returns the workflow definition that applies to a specific collection eventually fallback to the default configuration 
+
+### Linked entities
+#### collections
+**/api/config/workflowdefinitions/<:definition-name>/collections**
+
+It returns the list of collections that make an explicit use of the workflow-definition.  
+If a collection doesn't specify the workflow-definition to be used, the default mapping applies, but this collection is not included in the list returned by this method
+
+#### steps
+**/api/config/workflowdefinitions/<:definition-name>/steps**
+
+It returns the list of workflow-steps used in the workflow-definition, see [workflowsteps.md](workflowsteps.md)

--- a/workflowdefinitions.md
+++ b/workflowdefinitions.md
@@ -4,7 +4,7 @@
 A workflow definition is defined globally or per collection.  
 It defines the list of steps to use in the workflow per collection, and the default steps.
 
-All endpoints mentioned here require authentication, but no specific permissions
+All endpoints mentioned here require authentication, but no specific permissions.
 
 ## Main Endpoint
 **/api/config/workflowdefinitions**   
@@ -14,7 +14,7 @@ Provide access to the configured workflow definitions. It returns the list of co
 ## Single Workflow Definition
 **/api/config/workflowdefinitions/<:definition-name>**
 
-Provide detailed information about a specific workflow definition. The JSON response document is as follow
+Provide detailed information about a specific workflow definition. The JSON response document is as follows:
 ```json
 {
   "name": "default",
@@ -31,16 +31,16 @@ Exposed links:
 #### findByCollection
 **/api/config/workflowdefinitions/search/findByCollection?uuid=<:collection-uuid>**
 
-It returns the workflow definition that applies to a specific collection eventually fallback to the default configuration 
+It returns the workflow definition that applies to a specific collection eventually fallback to the default configuration.
 
 ### Linked entities
 #### collections
 **/api/config/workflowdefinitions/<:definition-name>/collections**
 
 It returns the list of collections that make an explicit use of the workflow-definition.  
-If a collection doesn't specify the workflow-definition to be used, the default mapping applies, but this collection is not included in the list returned by this method
+If a collection doesn't specify the workflow-definition to be used, the default mapping applies, but this collection is not included in the list returned by this method.
 
 #### steps
 **/api/config/workflowdefinitions/<:definition-name>/steps**
 
-It returns the list of workflow-steps used in the workflow-definition, see [workflowsteps.md](workflowsteps.md)
+It returns the list of workflow-steps used in the workflow-definition. See [workflowsteps.md](workflowsteps.md).

--- a/workflowdefinitions.md
+++ b/workflowdefinitions.md
@@ -4,12 +4,12 @@
 A workflow definition is defined globally or per collection.  
 It defines the list of steps to use in the workflow per collection, and the default steps.
 
-All endpoints mentioned here require authentication
+All endpoints mentioned here require authentication, but no specific permissions
 
 ## Main Endpoint
 **/api/config/workflowdefinitions**   
 
-Provide access to the configured workflow definitions. It returns the list of existent workflow-definitions.
+Provide access to the configured workflow definitions. It returns the list of configured workflow-definitions.
 
 ## Single Workflow Definition
 **/api/config/workflowdefinitions/<:definition-name>**

--- a/workflowsteps.md
+++ b/workflowsteps.md
@@ -1,0 +1,31 @@
+# Workflow Steps Endpoints
+[Back to the list of all defined endpoints](endpoints.md)
+
+A workflow step represents a single step in the reviewing process, e.g. the accept/reject step.  
+
+All endpoints mentioned here require authentication
+
+## Main Endpoint
+**/api/config/workflowsteps**   
+
+Provide access to the configured workflow steps. It returns the list of existent workflow-steps.
+
+## Single Workflow Step Definition
+**/api/config/workflowsteps/<:step-name>**
+
+Provide detailed information about a specific workflow step. An example JSON response document:
+```json
+{
+  	"id": "editstep",
+    "actions": [
+        "approve",
+        "reject",
+        "edit_metadata"
+    ],
+  	"type": "workflowstep"
+}
+```
+
+The **actions** property contains the list of actions the user is authorized to perform in this step:
+* The **edit_metadata** action implies the user can use the PATCH on the workflow item's submission sections to edit the metadata.
+* Other actions are considered to be buttons with an action sent to REST using a POST to the claimed task

--- a/workflowsteps.md
+++ b/workflowsteps.md
@@ -17,7 +17,7 @@ Provide detailed information about a specific workflow step. An example JSON res
 ```json
 {
   	"id": "editstep",
-  	"actions": [
+  	"options": [
   	    "approve",
   	    "reject",
   	    "edit_metadata"
@@ -26,6 +26,6 @@ Provide detailed information about a specific workflow step. An example JSON res
 }
 ```
 
-The **actions** property contains the list of actions the user is authorized to perform in this step:
-* The **edit_metadata** action implies the user can use the PATCH on the workflow item's submission sections to edit the metadata.
-* Other actions are considered to be actions sent to REST using a [POST to the claimed task](claimedtasks.md#post-method-single-resource-level)
+The **options** property contains the list of actions the user is authorized to perform in this step:
+* The **edit_metadata** option implies the user can use the PATCH on the workflow item's submission sections to edit the metadata.
+* Other options are considered to be command options sent to REST using a [POST to the claimed task](claimedtasks.md#post-method-single-resource-level)

--- a/workflowsteps.md
+++ b/workflowsteps.md
@@ -3,12 +3,12 @@
 
 A workflow step represents a single step in the reviewing process, e.g. the accept/reject step.  
 
-All endpoints mentioned here require authentication
+All endpoints mentioned here require authentication, but no specific permissions
 
 ## Main Endpoint
 **/api/config/workflowsteps**   
 
-Provide access to the configured workflow steps. It returns the list of existent workflow-steps.
+Provide access to the configured workflow steps. It returns the list of configured workflow-steps.
 
 ## Single Workflow Step Definition
 **/api/config/workflowsteps/<:step-name>**
@@ -17,11 +17,11 @@ Provide detailed information about a specific workflow step. An example JSON res
 ```json
 {
   	"id": "editstep",
-    "actions": [
-        "approve",
-        "reject",
-        "edit_metadata"
-    ],
+  	"actions": [
+  	    "approve",
+  	    "reject",
+  	    "edit_metadata"
+  	],
   	"type": "workflowstep"
 }
 ```

--- a/workflowsteps.md
+++ b/workflowsteps.md
@@ -3,7 +3,7 @@
 
 A workflow step represents a single step in the reviewing process, e.g. the accept/reject step.  
 
-All endpoints mentioned here require authentication, but no specific permissions
+All endpoints mentioned here require authentication, but no specific permissions.
 
 ## Main Endpoint
 **/api/config/workflowsteps**   
@@ -28,4 +28,4 @@ Provide detailed information about a specific workflow step. An example JSON res
 
 The **actions** property contains the list of actions the user is authorized to perform in this step:
 * The **edit_metadata** action implies the user can use the PATCH on the workflow item's submission sections to edit the metadata.
-* Other actions are considered to be buttons with an action sent to REST using a POST to the claimed task
+* Other actions are considered to be actions sent to REST using a POST to the claimed task

--- a/workflowsteps.md
+++ b/workflowsteps.md
@@ -28,4 +28,4 @@ Provide detailed information about a specific workflow step. An example JSON res
 
 The **actions** property contains the list of actions the user is authorized to perform in this step:
 * The **edit_metadata** action implies the user can use the PATCH on the workflow item's submission sections to edit the metadata.
-* Other actions are considered to be actions sent to REST using a POST to the claimed task
+* Other actions are considered to be actions sent to REST using a [POST to the claimed task](claimedtasks.md#post-method-single-resource-level)


### PR DESCRIPTION
The configurable workflow supports configurable and customizable steps. Depending on the workflow step, different features are supported, and different buttons should be displayed.
The configuration should be exposed using the REST contract. This should ensure the UI will be able to identify whether Accept, Reject and/or Edit metadata buttons should be displayed for the basic steps.
More advanced workflow steps such as the select reviewer step and the score review step may need additional configuration, but that part has not been included for this initial REST Contract to keep the complexity limited.

Sample actions are already documented at https://github.com/DSpace/Rest7Contract/blob/master/claimedtasks.md#post-method-single-resource-level