### PR TITLE
DS-3533 Update projections contract to match impl

### DIFF
--- a/projections.md
+++ b/projections.md
@@ -1,29 +1,41 @@
 # Projections
 [REST Overview Documentation](README.md)
 
-## Questions
-* How does an object convey its level of initialization (distinguishing empty from uninitialized)?
-* Should an object know its own projection level?
+All `GET` requests returning a HAL document support an optional *projection* argument, specifying the name
+of an alternative representation of the requested resource.
 
-## Projection = default
-* Populate metadata
+Projections may add to, modify, or omit information from the default representation of a resource.
 
-## Projection = context
-Perhaps this should be the default.
+When fulfilling a request, the active projection is applied to the primary resource being requested
+as well as any embedded resources.
 
-* populate id, name, handle
-* populate unique object attributes (such as discoverable, withdrawn)
-* populate metadata
-* populate link to parent object (breadcrumb projection)
-* populate link to child objects (child projection)
+## Standard Projections
 
-## Projection = breadcrumb
-* populate id, name, handle
-* populate parent object (breadcrumb projection)
+There are two standard projections available in all DSpace 7+ instances:
 
-## Projection = child
-* populate id, nanme, handle
+### Default Projection
 
-## Projection = descendant
-* populate id, name, handle
-* populate child objects (child projection)
+The _default_ projection makes no changes to the normal representation of the resource and **excludes all
+subresource embeds**, omitting altogether the `_embed` section of the HAL representation.
+
+This is the implicit projection for all individual resource endpoints, such as `/api/core/items/<:uuid>`,
+if no projection is specified.
+
+### Full Projection (`?projection=full`)
+
+The _full_ projection includes all linked subresources also embedded in the response.
+
+Since embeds may include other embedded resources, it is important to limit the number of embed levels
+alloweds. Thus, only two levels of embeds will be returned at maximum when the _full_ projection is requested.
+
+## Custom Projections
+
+Developers and integrators may extend the available projections for use with a DSpace instance by adding
+a new uniquely-named `Projection` as a Java Spring `@Component`, and ensuring it is deployed (e.g. as a jar)
+within the DSpace server webapp.
+
+Upon successful component discovery, the projection will automatically become available for use with all
+REST API endpoints using the same syntax as the standard projections (`?projection=name`).
+
+See [the Projection javadocs](https://github.com/DSpace/DSpace/blob/master/dspace-server-webapp/src/main/java/org/dspace/app/rest/projection/Projection.java)
+for more information.

--- a/projections.md
+++ b/projections.md
@@ -16,7 +16,7 @@ There are two standard projections available in all DSpace 7+ instances:
 ### Default Projection
 
 The _default_ projection makes no changes to the normal representation of the resource and **excludes all
-subresource embeds**, omitting altogether the `_embed` section of the HAL representation.
+subresource embeds**, omitting altogether the `_embedded` section of the HAL representation.
 
 This is the implicit projection for all individual resource endpoints, such as `/api/core/items/<:uuid>`,
 if no projection is specified.


### PR DESCRIPTION
This just updates the old `projections.md` to bring it in line with the agreed implementation thus far.