### PR TITLE
Workflow actions (update)

### DIFF
--- a/claimedtasks.md
+++ b/claimedtasks.md
@@ -35,6 +35,13 @@ It returns the underlying workflowitem holds by the task. See the [workflowitem 
 
 It returns the eperson that own the task. See the [eperson endpoint for more info](epersons.md). This is a **read-only** endpoint, once the task is claimed the owner cannot be changed. To unclaim a task see the DELETE method below
 
+#### workflow action
+**/api/workflow/claimedtasks/<:id>/action** (READ-ONLY)
+
+It returns the workflow action currently assigned to the task.
+See the [workflow actions](workflowactions.md) endpoint for more info.
+This is a **read-only** endpoint, the [POST to the claimed task](#post-method-single-resource-level) is used to perform the action
+
 ### Search methods
 #### findByUser
 **/api/workflow/claimedtasks/search/findByUser?uuid=<:user-uuid>**

--- a/pooltasks.md
+++ b/pooltasks.md
@@ -41,6 +41,12 @@ It returns the eperson that can claim the task. See the [eperson endpoint for mo
 
 It returns the group of epersons that can claim the task. See the [group endpoint for more info](epersongroups.md). This is a **read-only** endpoint, once the task is created the backend group cannot be changed.
 
+#### workflow action
+**/api/workflow/pooltasks/<:id>/action** (READ-ONLY)
+
+It returns the workflow action currently assigned to the task.
+See the [workflow actions](workflowactions.md) endpoint for more info.
+This is a **read-only** endpoint, the [POST to the claimed task](#post-method-single-resource-level) is used to perform the action
 
 ### Search methods
 #### findByUser

--- a/workflowactions.md
+++ b/workflowactions.md
@@ -1,0 +1,31 @@
+# Workflow Actions Endpoints
+[Back to the list of all defined endpoints](endpoints.md)
+
+A workflow action represents a single action in the reviewing process, e.g. the accept/reject action.  
+
+All endpoints mentioned here require authentication, but no specific permissions.
+
+## Main Endpoint
+**/api/config/workflowactions**   
+
+The main endpoint is not implemented and a 405 error code is returned according to our [general error response codes](README.md#Error codes).
+
+## Single Workflow Action Definition
+**/api/config/workflowactions/<:action-name>**
+
+Provide detailed information about a specific workflow action. An example JSON response document:
+```json
+{
+  	"id": "editaction",
+  	"options": [
+  	    "approve",
+  	    "reject",
+  	    "edit_metadata"
+  	],
+  	"type": "workflowaction"
+}
+```
+
+The **options** property contains the list of actions the user is authorized to perform in this step:
+* The **edit_metadata** option implies the user can use the PATCH on the workflow item's submission sections to edit the metadata.
+* Other options are considered to be command options sent to REST using a [POST to the claimed task](claimedtasks.md#post-method-single-resource-level)

--- a/workflowsteps.md
+++ b/workflowsteps.md
@@ -8,7 +8,7 @@ All endpoints mentioned here require authentication, but no specific permissions
 ## Main Endpoint
 **/api/config/workflowsteps**   
 
-Provide access to the configured workflow steps. It returns the list of configured workflow-steps.
+The main endpoint is not implemented and a 405 error code is returned according to our [general error response codes](README.md#Error-codes).
 
 ## Single Workflow Step Definition
 **/api/config/workflowsteps/<:step-name>**

--- a/workflowsteps.md
+++ b/workflowsteps.md
@@ -17,15 +17,27 @@ Provide detailed information about a specific workflow step. An example JSON res
 ```json
 {
   	"id": "editstep",
-  	"options": [
-  	    "approve",
-  	    "reject",
-  	    "edit_metadata"
-  	],
-  	"type": "workflowstep"
+  	"type": "workflowstep",
+    "_links": {
+      "workflowactions": {
+        "href": "https://dspace7-entities.atmire.com/rest/api/config/workflowsteps/<:step-name>/workflowactions"
+      }
+    },
+    "_embedded": {
+      "workflowactions": 
+        [
+          {
+            "id": "editaction",
+            "options": [
+                "approve",
+                "reject",
+                "edit_metadata"
+            ],
+            "type": "workflowaction"
+          }
+        ]
+    }
 }
 ```
 
-The **options** property contains the list of actions the user is authorized to perform in this step:
-* The **edit_metadata** option implies the user can use the PATCH on the workflow item's submission sections to edit the metadata.
-* Other options are considered to be command options sent to REST using a [POST to the claimed task](claimedtasks.md#post-method-single-resource-level)
+It includes the list of workflow actions used in the workflow step. See [Workflow Actions Endpoints](workflowactions.md) for more details


### PR DESCRIPTION
In the previous workflow contract, I had forgotten difference between a workflow step and a workflow action. A workflow step typically has only one workflow action (that's why I had forgotten about it), but multiple are possible.
I've adjusted the REST contract to make this differentiation