### PR TITLE
fixed rest contracts concerning  DS-4428

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -91,6 +91,29 @@ Exposed links:
 * defaultAccessConditions: link to the resource policies applied by default to new submissions in the collection
 * parentCommunity: the community containing this collection
 
+### Search methods
+#### findAuthorized
+**/api/core/collections/search/findAuthorized**
+
+The supported parameters are:
+* page, size [see pagination](README.md#Pagination)
+It returns the list of collections where the current user is authorized to submit
+
+Return codes:
+* 200 OK - if the operation succeed
+
+#### findAuthorizedByCommunity
+**/api/core/collections/search/findAuthorizedByCommunity?uuid=<:uuid>**
+
+The supported parameters are:
+* page, size [see pagination](README.md#Pagination)
+* uuid: mandatory, the uuid of the community
+It returns the list of collections direct children of the specified community where the current user is authorized to submit
+
+Return codes:
+* 200 OK - if the operation succeed
+* 400 Bad Request - if the uuid parameter is missing or invalid
+
 ## Patch operations
 
 Collection metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).

--- a/communities.md
+++ b/communities.md
@@ -220,6 +220,10 @@ The supported parameters are:
 * **(mandatory)** parent, the UUID of the parent community
 * page, size [see pagination](README.md#Pagination)
 
+Return codes:
+* 200 OK - if the operation succeed
+* 400 Bad Request - if the uuid parameter is missing or invalid
+
 ## Creating communities
 
 ### Creating top level community

--- a/epersons.md
+++ b/epersons.md
@@ -7,6 +7,35 @@
 ## Single EPerson
 **/api/eperson/epersons/<:uuid>**
 
+### Search methods
+#### byEmail
+**/api/eperson/epersons/search/byEmail?email=<:string>**
+
+The supported parameters are:
+* email: mandatory, EPerson's email to search
+
+It returns the EPersonRest instance, if any, matching the user query
+
+Return codes:
+* 200 OK - if the operation succeed
+* 400 Bad Request - if the email parameter is missing or invalid
+* 401 Unauthorized - if you are not authenticated
+* 403 Forbidden - if you are not logged in with sufficient permissions. Only system administrators and users with READ rights on the target EPerson can use the endpoint
+
+#### byName
+**/api/eperson/epersons/search/byName?q=<:string>**
+
+The supported parameters are:
+* q: mandatory, the search string
+
+It returns the list of EPersonRest instances, if any, matching the user query
+
+Return codes:
+* 200 OK - if the operation succeed
+* 400 Bad Request - if the email parameter is missing or invalid
+* 401 Unauthorized - if you are not authenticated
+* 403 Forbidden - if you are not logged in with sufficient permissions. Only system administrators and users with READ rights on the target EPerson can use the endpoint
+
 ## Patch operations
 
 EPerson metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).
@@ -59,8 +88,7 @@ For example, starting with the following eperson field data:
 the replace operation `[{ "op": "replace", "path": "/email", "value": "new@email"]` will result in :
 ```json
   "email": "new@email",
-  ```
-  
+  ```  
 #### This operation can be performed by administrators and by the authenticated user.
 
 To replace the password value, `curl -X PATCH http://${dspace.url}/api/eperson/epersons/<:id-eperson> -H "Content-Type: application/json" -d '[{ "op": "replace", "path": "/password", "value": "newpassword"]'`.  The operation also requires an Authorization header.

--- a/metadatafields.md
+++ b/metadatafields.md
@@ -47,6 +47,10 @@ The supported parameters are:
 * **(mandatory)** schema, the prefix of the metadata schema (i.e. "dc", "dcterms", "eperson, etc.)
 * page, size [see pagination](README.md#Pagination)
 
+Return codes:
+* 200 OK - if the operation succeed
+* 400 Bad Request - if the email parameter is missing or invalid
+
 ## Creating a Metadata Field
 
 **POST /api/core/metadatafields?schemaId=<:schemaId>**


### PR DESCRIPTION
Add mention in the contract about the 400 return code where applicable.
Please note that most of the failing test after the switch from 422 to 400 where related to undocumented endpoint, here I have documented the current situation except than for the security of the findByEmail method where I suggested to add security checks, see https://jira.lyrasis.org/browse/DS-4431