### PR TITLE
Link to workflow steps and actions

### DIFF
--- a/claimedtasks.md
+++ b/claimedtasks.md
@@ -21,6 +21,8 @@ Provide details about a specific task in the pool. The JSON response document is
 ```
 
 Exposed links:
+* step: the workflow step
+* action: the workflow action
 * workflowitem: the workflowitem underlying the task
 * owner: the eperson that own the task
 
@@ -34,6 +36,13 @@ It returns the underlying workflowitem holds by the task. See the [workflowitem 
 **/api/workflow/claimedtasks/<:id>/owner** (READ-ONLY)
 
 It returns the eperson that own the task. See the [eperson endpoint for more info](epersons.md). This is a **read-only** endpoint, once the task is claimed the owner cannot be changed. To unclaim a task see the DELETE method below
+
+#### workflow step
+**/api/workflow/claimedtasks/<:id>/step** (READ-ONLY)
+
+It returns the workflow step currently assigned to the task.
+See the [workflow steps](workflowsteps.md) endpoint for more info.
+This is a **read-only** endpoint
 
 #### workflow action
 **/api/workflow/claimedtasks/<:id>/action** (READ-ONLY)

--- a/pooltasks.md
+++ b/pooltasks.md
@@ -44,7 +44,7 @@ It returns the eperson that can claim the task. See the [eperson endpoint for mo
 It returns the group of epersons that can claim the task. See the [group endpoint for more info](epersongroups.md). This is a **read-only** endpoint, once the task is created the backend group cannot be changed.
 
 #### workflow step
-**/api/workflow/claimedtasks/<:id>/step** (READ-ONLY)
+**/api/workflow/pooltasks/<:id>/step** (READ-ONLY)
 
 It returns the workflow step currently assigned to the task.
 See the [workflow steps](workflowsteps.md) endpoint for more info.
@@ -55,7 +55,7 @@ This is a **read-only** endpoint
 
 It returns the workflow action currently assigned to the task.
 See the [workflow actions](workflowactions.md) endpoint for more info.
-This is a **read-only** endpoint, the [POST to the claimed task](#post-method-single-resource-level) is used to perform the action
+This is a **read-only** endpoint.
 
 ### Search methods
 #### findByUser

--- a/pooltasks.md
+++ b/pooltasks.md
@@ -21,6 +21,8 @@ Provide details about a specific task in the pool. The JSON response document is
 ```
 
 Exposed links:
+* step: the workflow step
+* action: the workflow action
 * workflowitem: the workflowitem underlying the task
 * eperson: the eperson that can claim the task
 * group: the group that can claim the task
@@ -40,6 +42,13 @@ It returns the eperson that can claim the task. See the [eperson endpoint for mo
 **/api/workflow/pooltasks/<:id>/group** (READ-ONLY)
 
 It returns the group of epersons that can claim the task. See the [group endpoint for more info](epersongroups.md). This is a **read-only** endpoint, once the task is created the backend group cannot be changed.
+
+#### workflow step
+**/api/workflow/claimedtasks/<:id>/step** (READ-ONLY)
+
+It returns the workflow step currently assigned to the task.
+See the [workflow steps](workflowsteps.md) endpoint for more info.
+This is a **read-only** endpoint
 
 #### workflow action
 **/api/workflow/pooltasks/<:id>/action** (READ-ONLY)

--- a/workflowitems.md
+++ b/workflowitems.md
@@ -87,6 +87,7 @@ Provide detailed information about a specific workflowitem. The JSON response do
 Similary  to the [Workspace Item](workspaceitems.md) the actual data of the inprogress submission are arranged in *sections* map following the sections configured in the submissionDefinition. This map is *open for extension*, each type of section will expose a different JSON structure. See the [out-of-box submission section types](submissionsection-types.md) page for details. An additional step attribute containing the id of the reached step in the workflow is present
 
 Exposed links:
+* step: the workflow step
 * collection: the collection where the inprogress submission will be created
 * item: the item that hold the submission data
 * submissionDefinition: the [submission definition](submissiondefinitions.md) used by this inprogress submission
@@ -115,6 +116,13 @@ It returns the submission definition used by the inprogress submission. See the 
 The submission definition used by the inprogress submission is derived from the inprogress submission attributes. In the default implementation the definition is derived from the collection where the submission is created and is updated if it changes. 
 Please note that this endpoint is not strictly necessary as you can currently retrieve the same definition using [/api/config/submissiondefinitions/search/findByCollection?uuid=<:workspaceitem-collection-uuid>](submissiondefinitions.md#findByCollection) but it allows the client to find the submissionDefinition embedded in the workspaceitem without the need to make a separate call. 
 In addition, it allows in future to change the 1:1 association between collections and submissionDefinition without breaking the client
+
+#### workflow step
+**/api/workflow/claimedtasks/<:id>/step** (READ-ONLY)
+
+It returns the workflow step currently assigned to the task.
+See the [workflow steps](workflowsteps.md) endpoint for more info.
+This is a **read-only** endpoint
 
 ### Search methods
 #### findBySubmitter

--- a/workflowitems.md
+++ b/workflowitems.md
@@ -118,9 +118,9 @@ Please note that this endpoint is not strictly necessary as you can currently re
 In addition, it allows in future to change the 1:1 association between collections and submissionDefinition without breaking the client
 
 #### workflow step
-**/api/workflow/claimedtasks/<:id>/step** (READ-ONLY)
+**/api/workflow/workflowitems/<:id>/step** (READ-ONLY)
 
-It returns the workflow step currently assigned to the task.
+It returns the workflow step of the workflow item
 See the [workflow steps](workflowsteps.md) endpoint for more info.
 This is a **read-only** endpoint
 


### PR DESCRIPTION
This includes links from claimed tasks, pooled tasks and workflow items to the configured workflow steps and actions
This should eventually replace the json properties, but Angular will need a transition period to migrate from the properties to the HAL links