### PR TITLE
Group/EPerson management continued

### DIFF
--- a/epersongroups.md
+++ b/epersongroups.md
@@ -62,6 +62,38 @@ Status codes:
 * 403 Forbidden - if you are not logged in with sufficient permissions
 * 422 Unprocessable Entity - if the name was omitted or already exists, if permanent was set to true
 
+## Deleting an EPerson Group
+
+**DELETE /api/eperson/groups/<:uuid>**
+
+Deletes the EPerson Group
+
+Status codes:
+* 204 No content - if the operation succeed
+* 401 Unauthorized - if you are not authenticated
+* 403 Forbidden - if you are not logged in with sufficient permissions, only general admins can delete a group
+* 404 Not found - if the Group doesn't exist (or was already deleted)
+
+## Patch operations
+**PATCH /api/eperson/groups/<:uuid>**
+
+EPerson Group metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).
+
+Additional properties can be modified via Patch as described below.
+
+### Replace
+The replace operation allows to replace *existent* information with new one.
+The only property which can be modified is the group name.
+
+To change the name of an EPerson Group, use
+`curl --data '[ { "op": "replace", "path": "/name", "value": "New Name"}]' -H "Authorization: Bearer ..." -H "content-type: application/json" -X PATCH ${dspace7-url}/api//eperson/groups/${group-uuid}`.
+
+Status codes:
+* 200 OK - if the operation succeeded
+* 401 Unauthorized - if you are not authenticated
+* 403 Forbidden - if you are not logged in with sufficient permissions, only general admins can patch a group
+* 404 Not found - if the Group doesn't exist (or was already deleted)
+
 ## Sub Groups in a single parent EPerson Group
 
 ### Get Sub Groups in a single parent EPerson Group
@@ -300,3 +332,9 @@ This supports a basic search in the metadata.
 It will search in:
 * UUID (exact match)
 * group name
+
+## Related DSpace Object of group
+**GET /api/eperson/groups/<:uuid>/dso**
+
+This returns the DSpace Object (Community, Collection) belonging to this Group.
+This is only applicable for roles in that DSpace Object, e.g. the Community Administrator or Collection Submitter Group

--- a/epersongroups.md
+++ b/epersongroups.md
@@ -93,6 +93,7 @@ Status codes:
 * 401 Unauthorized - if you are not authenticated
 * 403 Forbidden - if you are not logged in with sufficient permissions, only general admins can patch a group
 * 404 Not found - if the Group doesn't exist (or was already deleted)
+* 422 Unprocessable Entity - if the name cannot be modified (e.g. if permanent was set to true or the group is part of a DSpace Object)
 
 ## Sub Groups in a single parent EPerson Group
 
@@ -334,7 +335,7 @@ It will search in:
 * group name
 
 ## Related DSpace Object of group
-**GET /api/eperson/groups/<:uuid>/dso**
+**GET /api/eperson/groups/<:uuid>/object** (READ-ONLY)
 
 This returns the DSpace Object (Community, Collection) belonging to this Group.
 This is only applicable for roles in that DSpace Object, e.g. the Community Administrator or Collection Submitter Group

--- a/epersons.md
+++ b/epersons.md
@@ -75,11 +75,15 @@ Return codes:
 * 401 Unauthorized - if you are not authenticated
 * 403 Forbidden - if you are not logged in with sufficient permissions. Only system administrators and users with READ rights on the target EPerson can use the endpoint
 
-#### byName
-**/api/eperson/epersons/search/byName?q=<:string>**
+#### byMetadata
+**GET /api/eperson/epersons/search/byMetadata?query=<:name>**
 
-The supported parameters are:
-* q: mandatory, the search string
+This supports a basic search in the metadata.
+It will search in:
+* UUID (exact match)
+* first name
+* last name
+* email address
 
 It returns the list of EPersonRest instances, if any, matching the user query
 
@@ -206,13 +210,3 @@ This will return a pageable list of the groups this person is a direct member of
 
 > TODO: A solution to retrieve direct and indirect groups of an eperson is also required.
 > This would use GroupService.allMemberGroupsSet() and is used e.g. when viewing an EPerson as an admin
-
-## Search
-**GET /api/eperson/epersons/search/byMetadata?query=<:name>**
-
-This supports a basic search in the metadata.
-It will search in:
-* UUID (exact match)
-* first name
-* last name
-* email address


### PR DESCRIPTION
More changes required for the Group/EPerson management:
* Deleting a group
* Changing the group's name
* Retrieving e.g. the related collection if the group is a collection administrator group
* Searching EPerson byName removed, this is not supported in the backend, and is replace with a search by metadata (the latter was already approved, but moved it up now)