### PR TITLE
Login-as using WWW-Authenticate

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -9,9 +9,12 @@ Information about the underline implementation are [available on the wiki](https
 
 This endpoint only accept the POST method. Parameters and body structure depend on the authentication method to use.
 
-A WWW-Authenticate header is returned listing the different authentication method supported by the system. Below an example listing the password and shibboleth authentication
-
+A WWW-Authenticate header is returned listing the different authentication method supported by the system.
+Below an example listing the password and shibboleth authentication:  
 `WWW-Authenticate: shibboleth realm="DSpace REST API", location="https://dspace7.4science.cloud/Shibboleth.sso/Login?target=https%3A%2F%2Fdspace7.4science.cloud", password realm="DSpace REST API"`
+
+An alternative response when Login-as and password login are available:  
+`WWW-Authenticate: loginas realm="DSpace REST API", password realm="DSpace REST API"`
 
 Return codes
 - 200 Ok. If the authentication succeed. The JWT will be returned in the response Header Authorization. 

--- a/authentication.md
+++ b/authentication.md
@@ -13,9 +13,6 @@ A WWW-Authenticate header is returned listing the different authentication metho
 Below an example listing the password and shibboleth authentication:  
 `WWW-Authenticate: shibboleth realm="DSpace REST API", location="https://dspace7.4science.cloud/Shibboleth.sso/Login?target=https%3A%2F%2Fdspace7.4science.cloud", password realm="DSpace REST API"`
 
-An alternative response when Login-as and password login are available:  
-`WWW-Authenticate: loginas realm="DSpace REST API", password realm="DSpace REST API"`
-
 Return codes
 - 200 Ok. If the authentication succeed. The JWT will be returned in the response Header Authorization. 
 - 401 Unauthorized. If the login fails. The response Header WWW-Authentication must be inspected to discover the supported authentication method
@@ -94,6 +91,7 @@ This will return the authentication status, E.G.:
 {
   "okay" : true,
   "authenticated" : true,
+  "allowOnBehalfOf" : false,
   "type" : "status",
   "_links" : {
     "eperson" : {
@@ -114,6 +112,7 @@ This will return the authentication status, E.G.:
 Fields
 - Okay: True if REST API is up and running, should never return false
 - Authenticated: True if the token is valid, false if there was no token or the token wasn't valid
+- allowOnBehalfOf: True if the user is an admin and login as is allowed
 - Type: Type of the endpoint, "status" in this case
 
 Links	
@@ -124,3 +123,20 @@ Embedded
 
 Return code
 - 200 Ok in all the scenario both authenticated than not authenticated (valid token, invalid token or missing token)
+
+## Log in as
+
+For any request, an `x-on-behalf-of` header can be included.
+If the user is authorized to use this header (the user is an admin and login as is allowed), the request will be processed using the account of the provided user
+
+Sample request: 
+```
+curl -v "http://{dspace-server.url}/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb" -H "Authorization: Bearer eyJhbG...COdbo" -H "x-on-behalf-of: 028dcbb8-0da2-4122-a0ea-254be49ca107"
+```
+
+The Authorization header remains the same, still linked to the actual admin using the `x-on-behalf-of` header.
+
+Status codes:
+* 400 Bad Request - if the x-on-behalf-of header doesn't contain a valid EPerson UUID
+* 403 Forbidden - if you are not authorized to act on behalf of the given user
+* Any status code of the functionality being used

--- a/authentication.md
+++ b/authentication.md
@@ -91,7 +91,6 @@ This will return the authentication status, E.G.:
 {
   "okay" : true,
   "authenticated" : true,
-  "allowOnBehalfOf" : false,
   "type" : "status",
   "_links" : {
     "eperson" : {
@@ -112,7 +111,6 @@ This will return the authentication status, E.G.:
 Fields
 - Okay: True if REST API is up and running, should never return false
 - Authenticated: True if the token is valid, false if there was no token or the token wasn't valid
-- allowOnBehalfOf: True if the user is an admin and login as is allowed
 - Type: Type of the endpoint, "status" in this case
 
 Links	
@@ -126,17 +124,18 @@ Return code
 
 ## Log in as
 
-For any request, an `x-on-behalf-of` header can be included.
-If the user is authorized to use this header (the user is an admin and login as is allowed), the request will be processed using the account of the provided user
+For any request, an `X-On-Behalf-Of` header can be included.
+If the user is authorized to use this header (the user is an admin and login as is allowed), the request will be processed using the account of the provided user.  
+Verifying whether the user is authorized to use this header can happen using the "loginOnBehalfOf" [feature](features.md), verified against the site
 
 Sample request: 
 ```
-curl -v "http://{dspace-server.url}/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb" -H "Authorization: Bearer eyJhbG...COdbo" -H "x-on-behalf-of: 028dcbb8-0da2-4122-a0ea-254be49ca107"
+curl -v "http://{dspace-server.url}/server/api/core/items/1911e8a4-6939-490c-b58b-a5d70f8d91fb" -H "Authorization: Bearer eyJhbG...COdbo" -H "X-On-Behalf-Of: 028dcbb8-0da2-4122-a0ea-254be49ca107"
 ```
 
-The Authorization header remains the same, still linked to the actual admin using the `x-on-behalf-of` header.
+The Authorization header remains the same, still linked to the actual admin using the `X-On-Behalf-Of` header.
 
 Status codes:
-* 400 Bad Request - if the x-on-behalf-of header doesn't contain a valid EPerson UUID
+* 400 Bad Request - if the X-On-Behalf-Of header doesn't contain a valid EPerson UUID
 * 403 Forbidden - if you are not authorized to act on behalf of the given user
 * Any status code of the functionality being used


### PR DESCRIPTION
The goal of the underlying implementation is:
* Login-as is migrated to an explicit AuthenticationMethod
* This AuthenticationMethod implementation will only act if the current user is an admin, and the login method is enabled (replacing the old `webui.user.assumelogin` boolean)
* It won't need a password, but still needs an email address or UUID

As part of the implementation, it would also be best to improve the EPersonRestAuthenticationProvider implementation, this will have an impact on the Angular UI as well:
* The Angular UI currently reads the WWW-Authenticate header to identify the `AuthenticationMethod` based on the getName() method
* If the Angular UI specifies which authentication method it attempts (posting to /server/api/authn/login with parameters method=password, user and password), this parameter can used by the EPersonRestAuthenticationProvider to only use the relevant AuthenticationMethod
* If one would configure password, LDAP, and login-as authentication, the system shouldn't randomly test them until one returns success, but should rather use this applicably method immediate