### PR TITLE
CC License

### DIFF
--- a/submissioncclicenses.md
+++ b/submissioncclicenses.md
@@ -113,3 +113,13 @@ Some licenses contain questions, e.g. standard retrieved from https://api.creati
 ```
 
 The fields are questions to be answered when assigning the license
+
+## Search CC License 
+**/api/config/submissioncclicenses/search/rightsByQuestions**
+
+Parameters:
+* license: the ID of the license (e.g. standard, publicdomain, …)
+* answer_X: List of answers (e.g. answer_commercial=y&answer_derivatives=sa)
+
+If the combination of the license and the answers is valid, it will return the license URI (e.g. http://creativecommons.org/licenses/by-nc-sa/3.0/us/ or http://creativecommons.org/publicdomain/zero/1.0/)
+

--- a/submissioncclicenses.md
+++ b/submissioncclicenses.md
@@ -1,0 +1,115 @@
+# Submission CC Licenses Endpoints
+[Back to the list of all defined endpoints](endpoints.md)
+
+The proposed structure is derived from the configuration options already available in DSpace 6 and below.
+In the first implementation, a single configuration named *default* is expected as these configurations were set at the site level.
+Introducing an endpoint to manage a collection of configurations we open the door to future extension where different setups can be used for different kind of submissions (theses, technical reports, journal articles, etc.)
+
+## Main Endpoint
+**/api/config/submissioncclicenses**   
+
+Provide access to the potential licenses for the CC license. It returns the list of configured CC licenses.
+
+This will correspond to e.g. https://api.creativecommons.org/rest/1.5/ filtered to only include the licenses which are configured for this repository
+
+```json
+{
+  "_embedded": {
+    "submissioncclicenses": [
+      {
+        "id": "publicdomain",
+        "name": "Public Domain",
+        "type": "submissioncclicenses",
+        "fields": []
+      },
+      {
+        "id": "mark",
+        "name": "Public Domain Mark",
+        "type": "submissioncclicenses",
+        "fields": []
+      }
+    ]
+  },
+  "page": {
+    "size": 20,
+    "totalElements": 2,
+    "totalPages": 1,
+    "number": 0
+  }
+}
+```
+
+## Single CC License 
+**/api/config/submissioncclicenses/<:license-name>**
+
+Provide detailed information about a specific license. Some licenses are basic, e.g. zero retrieved from https://api.creativecommons.org/rest/1.5/license/zero
+```json
+{
+  "id": "publicdomain",
+  "name": "CC0",
+  "type": "submissioncclicenses",
+  "fields": [],
+  "_links" : {
+    "self" : {
+      "href" : "/api/config/submissioncclicenses/publicdomain"
+    }
+  }
+}
+```
+
+Some licenses contain questions, e.g. standard retrieved from https://api.creativecommons.org/rest/1.5/license/standard
+```json
+{
+  "id": "standard",
+  "name": "CC0",
+  "type": "submissioncclicenses",
+  "fields": [
+    {
+      "id": "commercial",
+      "label": "Allow commercial uses of your work?",
+      "description": "The licensor permits others to copy, distribute and transmit the work. In return, licensees may not use the work for commercial purposes — unless they get the licensor's permission.",
+      "values": [
+        {
+          "id": "y",
+          "label": "Yes",
+          "description": "The licensor permits others to copy, distribute, display, and perform the work, including for commercial purposes."
+        },
+        {
+          "id": "n",
+          "label": "No",
+          "description": "The licensor permits others to copy, distribute, display, and perform the work for non-commercial purposes only."
+        }
+      ]
+    },
+    {
+      "id": "derivatives",
+      "label": "Allow modifications of your work?",
+      "description": "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it.",
+      "values": [
+        {
+          "id": "y",
+          "label": "Yes",
+          "description": "The licensor permits others to copy, distribute, display and perform the work, as well as make derivative works based on it."
+        },
+        {
+          "id": "sa",
+          "label": "ShareAlike",
+          "description": "The licensor permits others to distribute derivative works only under the same license or one compatible with the one that governs the licensor's work."
+        },
+        {
+          "id": "n",
+          "label": "No",
+          "description": "The licensor permits others to copy, distribute and transmit only unaltered copies of the work — not derivative works based on it."
+        }
+      ]
+    }
+  ],
+  "_links" : {
+    "self" : {
+      "href" : "/api/config/submissioncclicenses/standard"
+    }
+  }
+}
+```
+
+The fields are questions to be answered when assigning the license

--- a/submissionsection-types.md
+++ b/submissionsection-types.md
@@ -9,7 +9,7 @@ collection | n/a | ```json { collection: 'uuid-of-the-collection'}```
 submission-form | [/config/submissionforms](submissionforms.md) | [example](workspaceitem-data-metadata.md)
 upload | [/config/submissionuploads](submissionuploads.md) | [example](workspaceitem-data-upload.md)
 license | [it is retrieved from the collection following the *license* link](collections.md#License) | [example](workspaceitem-data-license.md)
-cclicense | t.b.d | t.b.d
+cclicense | [/config/submissioncclicenses](submissioncclicenses.md) | [example](workspaceitem-data-cclicense.md)
 access | t.b.d | t.b.d
 
 n/a --> not applicable. The sectionType doesn't require/support any extra configuration

--- a/workspaceitem-data-cclicense.md
+++ b/workspaceitem-data-cclicense.md
@@ -1,0 +1,84 @@
+# WorkspaceItem data of CC License sectionType
+[Back to the definition of the workspaceitems endpoint](workspaceitems.md)
+
+The section data represents the data about the CC license
+
+```json
+{
+  	"granted": true,
+  	"uri": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
+  	"rights": "Attribution-NonCommercial-ShareAlike 3.0 United States",
+	"file":  
+  	 	{
+          "uuid": "1ce6db0e-662f-4a13-ba87-c371ad664b14",
+          "name": "license_rdf",
+          "handle": null,
+          "metadata": {
+              "dc.title": [
+                {
+                  "value": "license_rdf",
+                  "language": null,
+                  "authority": null,
+                  "confidence": -1,
+                  "place": 0
+                }
+              ]
+          },
+          "sizeBytes": 1012,
+          "checkSum": {
+            "checkSumAlgorithm": "MD5",
+            "value": "59a4cfd819ce67ba7252efc52d1eb99b"
+          },
+          "sequenceId": 1,
+          "type": "bitstream"
+        }
+}
+```
+
+The following attributes can be defined:
+* granted: true if a CC License has been specified
+* uri: the URI of the CC License, typically stored in dc.rights.uri, can be null
+* rights: the rights name of the CC License, typically stored in dc.rights, can be null
+* file: the bitstream containing the license, can be null
+
+## Patch operations
+The PATCH method expects a JSON body according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902)
+
+Each successful Patch operation will return a HTTP 200 CODE with the new workspaceitem as body
+
+### Add
+To accept a CC license the client must send a JSON Patch ADD operation to the *granted* path
+
+```json
+[
+  {
+    "op": "add",
+    "path": "/sections/<:name-of-the-form>/granted",
+    "value": {
+      "license": "standard",
+      "fields": [
+          {
+            "id": "commercial",
+            "answer": "y"
+          },
+          {
+            "id": "derivatives",
+            "answer": "sa"
+          }
+        ]
+    }
+  }
+]
+```
+
+Please note that according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) a subsequent add operation on the granted will have the effect to replace the previous granted license with a new one. 
+In this case a new CC license will be added to the item and the previous license deleted.
+
+It is also possible to send a PATH add operation using *false* as value to reject / remove a license.
+
+This use of the add operation to replace the license could be counter intuitive but it is done according to the [RFC section 4.1](https://tools.ietf.org/html/rfc6902#section-4.1)
+> If the target location specifies an object member that does exist, that member's value is replaced.
+
+### Remove
+It is possible to remove a previously granted CC license 
+`curl --data '{[ { "op": "remove", "path": "/sections/cclicense/granted"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`

--- a/workspaceitem-data-cclicense.md
+++ b/workspaceitem-data-cclicense.md
@@ -5,7 +5,6 @@ The section data represents the data about the CC license
 
 ```json
 {
-  	"granted": true,
   	"uri": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/",
   	"rights": "Attribution-NonCommercial-ShareAlike 3.0 United States",
 	"file":  
@@ -36,10 +35,9 @@ The section data represents the data about the CC license
 ```
 
 The following attributes can be defined:
-* granted: true if a CC License has been specified
-* uri: the URI of the CC License, typically stored in dc.rights.uri, can be null
-* rights: the rights name of the CC License, typically stored in dc.rights, can be null
-* file: the bitstream containing the license, can be null
+* uri: the URI of the CC License, typically stored in dc.rights.uri, null is no license is granted
+* rights: the rights name of the CC License, typically stored in dc.rights, null is no license is granted
+* file: the bitstream containing the license, null is no license is granted
 
 ## Patch operations
 The PATCH method expects a JSON body according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902)
@@ -61,14 +59,12 @@ To accept a CC license the client must send a JSON Patch ADD operation of the ur
 
 The dc.rights, dc.rights.uri and RDF bitstream will be retrieved from e.g. https://api.creativecommons.org/rest/1.5/details?license-uri=http://creativecommons.org/licenses/by-nc-sa/3.0/ 
 
-Please note that according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) a subsequent add operation on the granted will have the effect to replace the previous granted license with a new one. 
+Please note that according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) a subsequent add operation on the `/sections/<:name-of-the-form>/uri` will have the effect to replace the previous granted license with a new one. 
 In this case a new CC license will be added to the item and the previous license deleted.
-
-It is also possible to send a PATH add operation using *false* as value to reject / remove a license.
 
 This use of the add operation to replace the license could be counter intuitive but it is done according to the [RFC section 4.1](https://tools.ietf.org/html/rfc6902#section-4.1)
 > If the target location specifies an object member that does exist, that member's value is replaced.
 
 ### Remove
 It is possible to remove a previously granted CC license 
-`curl --data '{[ { "op": "remove", "path": "/sections/cclicense/granted"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`
+`curl --data '{[ { "op": "remove", "path": "/sections/<:name-of-the-form>/uri"}]' -X PATCH ${dspace7-url}/api/submission/workspaceitems/1`

--- a/workspaceitem-data-cclicense.md
+++ b/workspaceitem-data-cclicense.md
@@ -47,29 +47,19 @@ The PATCH method expects a JSON body according to the [JSON Patch specification 
 Each successful Patch operation will return a HTTP 200 CODE with the new workspaceitem as body
 
 ### Add
-To accept a CC license the client must send a JSON Patch ADD operation to the *granted* path
+To accept a CC license the client must send a JSON Patch ADD operation of the uri retrieved from the [Search CC License](submissioncclicenses.md#search-cc-license)
 
 ```json
 [
   {
     "op": "add",
-    "path": "/sections/<:name-of-the-form>/granted",
-    "value": {
-      "license": "standard",
-      "fields": [
-          {
-            "id": "commercial",
-            "answer": "y"
-          },
-          {
-            "id": "derivatives",
-            "answer": "sa"
-          }
-        ]
-    }
+    "path": "/sections/<:name-of-the-form>/license",
+    "value": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/"
   }
 ]
 ```
+
+TODO: there's currently no way to extract the dc.rights or the RDF bitstream when the original answers are not present
 
 Please note that according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) a subsequent add operation on the granted will have the effect to replace the previous granted license with a new one. 
 In this case a new CC license will be added to the item and the previous license deleted.

--- a/workspaceitem-data-cclicense.md
+++ b/workspaceitem-data-cclicense.md
@@ -53,13 +53,13 @@ To accept a CC license the client must send a JSON Patch ADD operation of the ur
 [
   {
     "op": "add",
-    "path": "/sections/<:name-of-the-form>/license",
+    "path": "/sections/<:name-of-the-form>/uri",
     "value": "http://creativecommons.org/licenses/by-nc-sa/3.0/us/"
   }
 ]
 ```
 
-TODO: there's currently no way to extract the dc.rights or the RDF bitstream when the original answers are not present
+The dc.rights, dc.rights.uri and RDF bitstream will be retrieved from e.g. https://api.creativecommons.org/rest/1.5/details?license-uri=http://creativecommons.org/licenses/by-nc-sa/3.0/ 
 
 Please note that according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) a subsequent add operation on the granted will have the effect to replace the previous granted license with a new one. 
 In this case a new CC license will be added to the item and the previous license deleted.


### PR DESCRIPTION
This contains:
* Accessing the list of CC licenses based on the `cc.license.classfilter` configuration
* Representing the list of CC licenses and the fields (questions) per license
* Attaching the CC license (with answers to the questions) to the workspace item
* Verifying which CC license has been attached to the workspace item