### PR TITLE
Edit profile: edit metadata

### DIFF
--- a/epersons.md
+++ b/epersons.md
@@ -160,6 +160,9 @@ the replace operation `[{ "op": "replace", "path": "/password", "value": "newpas
 ```
 NOTE: The new password is currently returned after an update but this could be revisited later, see [#30]((https://github.com/DSpace/Rest7Contract/issues/30))
 
+Any EPerson metadata can be modified by both the administrator and by the authenticated user.  
+This includes, but is not limited to, last name, first name, phone, language
+
 ## Create new EPerson
 
 **POST /api/eperson/epersons**

--- a/epersons.md
+++ b/epersons.md
@@ -160,7 +160,7 @@ the replace operation `[{ "op": "replace", "path": "/password", "value": "newpas
 ```
 NOTE: The new password is currently returned after an update but this could be revisited later, see [#30]((https://github.com/DSpace/Rest7Contract/issues/30))
 
-Any EPerson metadata can be modified by both the administrator and by the authenticated user.  
+The currently authenticated user can modify their EPerson metadata. An administrator can modify any EPerson's metadata.  
 This includes, but is not limited to, last name, first name, phone, language
 
 ## Create new EPerson


### PR DESCRIPTION
The DSpace 7 UI allows a user to modify their name and preferred language, which is stored as EPerson metadata.
This minor change should make sure the metadata (but still not email, netid, …) can be updated by a regular user as well