### PR TITLE
Remove unnecessary exception in license PATCH

### DIFF
--- a/workspaceitem-data-license.md
+++ b/workspaceitem-data-license.md
@@ -83,8 +83,6 @@ will result in
 Please note that according to the [JSON Patch specification RFC6902](https://tools.ietf.org/html/rfc6902) a subsequent add operation on the granted will have the effect to replace the previous granted license with a new one. 
 In this case a new bitstream license will be added to the item and the previous license deleted, this mean that the *url* and *acceptedDate* attributes will change accordly.
 
-It is also possible to send a PATH add operation using *false* as value to reject / remove a license.
-
 This use of the add operation to replace the license could be counter intuitive but it is done according to the [RFC section 4.1](https://tools.ietf.org/html/rfc6902#section-4.1)
 > If the target location specifies an object member that does exist, that member's value is replaced.
 


### PR DESCRIPTION
There's no need for exceptions on the ADD behavior and using ADD to remove data. Remove should be used to remain consistent

The remove is already supported: https://github.com/DSpace/Rest7Contract/blob/master/workspaceitem-data-license.md#remove

The only change is remove the odd "ADD" patch to remove a license