### PR TITLE
Download authorizations

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -121,3 +121,27 @@ Embedded
 
 Return code
 - 200 Ok in all the scenario both authenticated than not authenticated (valid token, invalid token or missing token)
+
+## Request download token
+
+** POST /api/authn/download-token **
+
+When clicking on a link to download a protected file in the UI no authentication header will be sent along. This endpoint can provide a short lived token (MAX 2 seconds) that the UI can append to file downloads.
+ 
+The token follows the "JSON Web Token structure", same as the login tokens.
+  
+ 
+ ```json
+{
+  "token": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJlaWQiOiJjZDgyNGE2MS05NWJlLTRlMTYtYmNjZC01MWZlYTI2NzA3ZDAiLCJzZyI6W10sImV4cCI6MTU5MDQxMzUwNn0.XRK4ldh9l4My45gJzLtcW97hVUpbtM5oAQsxuQ2V37c",
+  "_links": {
+    "self": {
+      "href": "http://${dspace-server.url}/api/authn/download-token"
+    }             
+  }
+}
+```  
+
+Return codes
+- 200 Ok. 
+- 401 Unauthorized. If no user is logged in

--- a/authentication.md
+++ b/authentication.md
@@ -152,7 +152,7 @@ The token follows the "JSON Web Token structure", same as the login tokens.
  
  ```json
 {
-  "token": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJlaWQiOiJjZDgyNGE2MS05NWJlLTRlMTYtYmNjZC01MWZlYTI2NzA3ZDAiLCJzZyI6W10sImV4cCI6MTU5MDQxMzUwNn0.XRK4ldh9l4My45gJzLtcW97hVUpbtM5oAQsxuQ2V37c",
+  "token": "eyJhbGciOiJIUzI1NiJ9.eyJlaWQiOiJjZDgyNGE2MS05NWJlLTRlMTYtYmNjZC01MWZlYTI2NzA3ZDAiLCJzZyI6W10sImV4cCI6MTU5MDQxMzUwNn0.XRK4ldh9l4My45gJzLtcW97hVUpbtM5oAQsxuQ2V37c",
   "_links": {
     "self": {
       "href": "http://${dspace-server.url}/api/authn/download-token"

--- a/authentication.md
+++ b/authentication.md
@@ -149,6 +149,9 @@ When clicking on a link to download a protected file in the UI no authentication
  
 The token follows the "JSON Web Token structure", same as the login tokens.
   
+ ```
+ curl -v -X POST https://{dspace-server.url}/api/authn/download-token -H "Authorization: Bearer eyJhbG...COdbo"
+ ```
  
  ```json
 {

--- a/authentication.md
+++ b/authentication.md
@@ -141,16 +141,16 @@ Status codes:
 * Any status code of the functionality being used
 
 
-## Request download token
+## Request short lived token
 
-** POST /api/authn/download-token **
+** POST /api/authn/shortlivedtokens **
 
 When clicking on a link to download a protected file in the UI no authentication header will be sent along. This endpoint can provide a short lived token (MAX 2 seconds) that the UI can append to file downloads.
  
 The token follows the "JSON Web Token structure", same as the login tokens.
   
  ```
- curl -v -X POST https://{dspace-server.url}/api/authn/download-token -H "Authorization: Bearer eyJhbG...COdbo"
+ curl -v -X POST https://{dspace-server.url}/api/authn/shortlivedtokens -H "Authorization: Bearer eyJhbG...COdbo"
  ```
  
  ```json
@@ -158,7 +158,7 @@ The token follows the "JSON Web Token structure", same as the login tokens.
   "token": "eyJhbGciOiJIUzI1NiJ9.eyJlaWQiOiJjZDgyNGE2MS05NWJlLTRlMTYtYmNjZC01MWZlYTI2NzA3ZDAiLCJzZyI6W10sImV4cCI6MTU5MDQxMzUwNn0.XRK4ldh9l4My45gJzLtcW97hVUpbtM5oAQsxuQ2V37c",
   "_links": {
     "self": {
-      "href": "http://${dspace-server.url}/api/authn/download-token"
+      "href": "http://${dspace-server.url}/api/authn/shortlivedtokens"
     }             
   }
 }

--- a/bitstreams.md
+++ b/bitstreams.md
@@ -103,7 +103,7 @@ Example: <http://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/8d33
 It returns the actual content (bits) described by the bitstream
 
 Supported Request Parameter:
-* **Token**: optional parameter that allows downloads for restricted files, a token needs to be requested from the [following endpoint](authentication.md#Request download token) 
+* **Token**: optional parameter that allows downloads for restricted files, a token needs to be requested from the [following endpoint](authentication.md#Request-download-token) 
 
 Response Headers:
 

--- a/bitstreams.md
+++ b/bitstreams.md
@@ -103,7 +103,7 @@ Example: <http://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/8d33
 It returns the actual content (bits) described by the bitstream
 
 Supported Request Parameter:
-* **Token**: optional parameter that allows downloads for restricted files, a token needs to be requested from the [following endpoint](authentication.md#Request-download-token) 
+* **token**: optional parameter that allows downloads for restricted files, a token needs to be requested from the [following endpoint](authentication.md#Request-download-token) 
 
 Response Headers:
 

--- a/bitstreams.md
+++ b/bitstreams.md
@@ -103,7 +103,7 @@ Example: <http://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/8d33
 It returns the actual content (bits) described by the bitstream
 
 Supported Request Parameter:
-* **token**: optional parameter that allows downloads for restricted files, a token needs to be requested from the [following endpoint](authentication.md#Request-download-token) 
+* **token**: optional parameter that allows downloads for restricted files, a token needs to be requested from the [following endpoint](authentication.md#Request-short-lived-token) 
 
 Response Headers:
 

--- a/bitstreams.md
+++ b/bitstreams.md
@@ -102,6 +102,9 @@ Example: <http://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/8d33
 
 It returns the actual content (bits) described by the bitstream
 
+Supported Request Parameter:
+* **Token**: optional parameter that allows downloads for restricted files, a token needs to be requested from the [following endpoint](authentication.md#Request download token) 
+
 Response Headers:
 
 * **ETag**: contains the md5 checksum as recorded in the bitstream record


### PR DESCRIPTION
This PR includes a new endpoint to retrieve short lived tokes that can be used for file downloads if the file is restricted.

The problems & the abstract description of the solution can be found here: https://github.com/DSpace/dspace-angular/issues/631

### Implementation details

**Authenticating the token**

Authentication is currently done here: https://github.com/DSpace/DSpace/blob/master/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/StatelessAuthenticationFilter.java#L120-L125, this calls on the "JWTTokenRestAuthenticationServiceImpl" to do the actual authentication. In the end the "JWTTokenHandler" class is called to provide / resolve the token, this "JWTTokenHandler" will become an abstract class with 2 implementations:
- JWTSessionTokenHandler
- JWTParameterTokenHandler

All code moves to the abstract class except for the following (or parts of them) method:
- afterPropertiesSet() => We will be using different secret, expiration time for both of these

In essence the changes above will ensure that the new parameter tokens are just as secure as the existing ones for longer sessions. They use the same code, just the retrieval & settings differ.

**Generating the token**

If we have 2 token handlers our new endpoint can then use the "JWTParameterTokenHandler" to generate a short lived token. 