### PR TITLE
Authorization for Downloads of restricted Bitstreams: Short lived token endpoint

### DIFF
--- a/authentication.md
+++ b/authentication.md
@@ -168,3 +168,12 @@ The token follows the "JSON Web Token structure", same as the login tokens.
 Return codes
 - 200 Ok. 
 - 401 Unauthorized. If no user is logged in
+
+### Using short lived token
+
+The request parameter below can be used for nearly every REST endpoint to perform it with authentication but without needing the authentication header:
+* **authentication-token**: optional parameter that authenticates a user, a token needs to be requested from the [following endpoint](authentication.md#Request-short-lived-token) 
+
+The following endpoints are not allowed to use the authentication-token:
+* **POST /api/authn/login**: refreshing your long-lived authentication header is not allowed using the short lived token
+* **POST /api/authn/shortlivedtokens**: creating a new short lived token is not allowed using the short lived token

--- a/bitstreams.md
+++ b/bitstreams.md
@@ -102,7 +102,7 @@ Example: <http://dspace7.4science.it/dspace-spring-rest/api/core/bitstreams/8d33
 It returns the actual content (bits) described by the bitstream
 
 Supported Request Parameter:
-* **token**: optional parameter that allows downloads for restricted files, a token needs to be requested from the [following endpoint](authentication.md#Request-short-lived-token) 
+* **authentication-token**: optional parameter that allows downloads for restricted files, a token needs to be requested from the [following endpoint](authentication.md#Request-short-lived-token) 
 
 Response Headers:
 


### PR DESCRIPTION
This is a continuation of https://github.com/DSpace/Rest7Contract/pull/126, based on a problem identified in https://github.com/DSpace/DSpace/pull/2783#issuecomment-652248755

It renames the parameter from token to authentication-token

It also explicitly mentions which endpoints are not allowed to use the authentication-token