### PR TITLE
Metadata field search

### DIFF
--- a/metadatafields.md
+++ b/metadatafields.md
@@ -50,18 +50,18 @@ Return codes:
 * 200 OK - if the operation succeed
 
 #### byLabel
-**/api/core/metadatafields/search/byLabel**
+**/api/core/metadatafields/search/byFieldName**
 
 This endpoint supports the parameters (any combination of parameters is allowed):
 * schema, an exact match of the prefix of the metadata schema (e.g. "dc", "dcterms", "eperson")
 * element, an exact match of the field's element (e.g. "contributor", "title")
 * qualifier, an exact match of the field's qualifier (e.g. "author", "alternative")
-* label, part of the fully qualified field, should start with the start of the schema, element or qualifier (e.g. "dc.ti", "contributor", "auth", "contributor.ot")
+* query, part of the fully qualified field, should start with the start of the schema, element or qualifier (e.g. "dc.ti", "contributor", "auth", "contributor.ot")
 * page, size [see pagination](README.md#Pagination)
 
 Examples:
-* /api/core/metadatafields/search/byLabel?schema=dc&label=author
-* /api/core/metadatafields/search/byLabel?label=id&qualifier=uri
+* /api/core/metadatafields/search/byLabel?schema=dc&query=author
+* /api/core/metadatafields/search/byLabel?query=id&qualifier=uri
 
 Return codes:
 * 200 OK - if the operation succeed

--- a/metadatafields.md
+++ b/metadatafields.md
@@ -60,8 +60,8 @@ This endpoint supports the parameters (any combination of parameters is allowed)
 * page, size [see pagination](README.md#Pagination)
 
 Examples:
-* /api/core/metadatafields/search/byLabel?schema=dc&query=author
-* /api/core/metadatafields/search/byLabel?query=id&qualifier=uri
+* /api/core/metadatafields/search/byFieldName?schema=dc&query=author
+* /api/core/metadatafields/search/byFieldName?query=id&qualifier=uri
 
 Return codes:
 * 200 OK - if the operation succeed

--- a/metadatafields.md
+++ b/metadatafields.md
@@ -14,7 +14,6 @@ Example: <http://dspace7.4science.it/dspace-spring-rest/#/dspace-spring-rest/api
 Provide detailed information about a specific metadata schema. The JSON response document is as follow
 ```json
 {
-  {
   "id": 8,
   "element": "contributor",
   "qualifier": "advisor",
@@ -49,7 +48,23 @@ The supported parameters are:
 
 Return codes:
 * 200 OK - if the operation succeed
-* 400 Bad Request - if the email parameter is missing or invalid
+
+#### byLabel
+**/api/core/metadatafields/search/byLabel**
+
+This endpoint supports the parameters (any combination of parameters is allowed):
+* schema, an exact match of the prefix of the metadata schema (e.g. "dc", "dcterms", "eperson")
+* element, an exact match of the field's element (e.g. "contributor", "title")
+* qualifier, an exact match of the field's qualifier (e.g. "author", "alternative")
+* label, part of the fully qualified field, should start with the start of the schema, element or qualifier (e.g. "dc.ti", "contributor", "auth", "contributor.ot")
+* page, size [see pagination](README.md#Pagination)
+
+Examples:
+* /api/core/metadatafields/search/byLabel?schema=dc&label=author
+* /api/core/metadatafields/search/byLabel?label=id&qualifier=uri
+
+Return codes:
+* 200 OK - if the operation succeed
 
 ## Creating a Metadata Field
 

--- a/metadatafields.md
+++ b/metadatafields.md
@@ -49,7 +49,7 @@ The supported parameters are:
 Return codes:
 * 200 OK - if the operation succeed
 
-#### byLabel
+#### byFieldName
 **/api/core/metadatafields/search/byFieldName**
 
 This endpoint supports the parameters (any combination of parameters is allowed):


### PR DESCRIPTION
This solves https://github.com/DSpace/dspace-angular/issues/750

Instead of expecting Angular to load all metadata fields to filter, Angular just needs to load the first 10, and can send the query directly to REST when the user starts typing