### PR TITLE
Metadata field: retrieve by exact name

### DIFF
--- a/metadatafields.md
+++ b/metadatafields.md
@@ -25,34 +25,6 @@ Provide detailed information about a specific metadata field. The JSON response 
 Exposed links:
 * schema: the metadata schema to which the item belongs 
 
-## Single Metadata Field by name
-**/api/core/metadatafields/name/<:metadata-field-full-name>**
-
-Provide detailed information about a specific metadata field based on the name.  
-This is not a search, it will only return one value if there's an exact match, or a 404 if the requested field doesn't exist
-
-The JSON response document for /api/core/metadatafields/name/dc.contributor.advisor is
-
-```json
-{
-  "id": 8,
-  "element": "contributor",
-  "qualifier": "advisor",
-  "scopeNote": "Use primarily for thesis advisor.",
-  "type": "metadatafield"
-}
-```
-
-
-When using /api/core/metadatafields/name/dc.title, it will only return the field without a qualifier
-
-Exposed links:
-* schema: the metadata schema to which the item belongs
-
-Return codes:
-* 200 OK - if the field exists
-* 404 Not found - if the field doesn't exist
-
 ## Linked entities
 ### Schema
 **/api/core/metadatafields/<:id>/schema**
@@ -83,6 +55,7 @@ This endpoint supports the parameters (any combination of parameters is allowed)
 * element, an exact match of the field's element (e.g. "contributor", "title")
 * qualifier, an exact match of the field's qualifier (e.g. "author", "alternative")
 * query, part of the fully qualified field, should start with the start of the schema, element or qualifier (e.g. "dc.ti", "contributor", "auth", "contributor.ot")
+* exactName, The exact fully qualified field, should use the syntax schema.element.qualifier or schema.element if no qualifier exists (e.g. "dc.title", "dc.contributor.author"). It will only return one value if there's an exact match
 * page, size [see pagination](README.md#Pagination)
 
 Examples:

--- a/metadatafields.md
+++ b/metadatafields.md
@@ -11,21 +11,47 @@ Example: <http://dspace7.4science.it/dspace-spring-rest/#/dspace-spring-rest/api
 ## Single Metadata Field
 **/api/core/metadatafields/<:id>**
 
-Provide detailed information about a specific metadata schema. The JSON response document is as follow
+Provide detailed information about a specific metadata field. The JSON response document is as follows
 ```json
 {
   "id": 8,
   "element": "contributor",
   "qualifier": "advisor",
   "scopeNote": "Use primarily for thesis advisor.",
-  "type": "metadatafield",
-   "_links": {...},
-   "_embedded": {...}
+  "type": "metadatafield"
 }
 ```
 
 Exposed links:
 * schema: the metadata schema to which the item belongs 
+
+## Single Metadata Field by name
+**/api/core/metadatafields/name/<:metadata-field-full-name>**
+
+Provide detailed information about a specific metadata field based on the name.  
+This is not a search, it will only return one value if there's an exact match, or a 404 if the requested field doesn't exist
+
+The JSON response document for /api/core/metadatafields/name/dc.contributor.advisor is
+
+```json
+{
+  "id": 8,
+  "element": "contributor",
+  "qualifier": "advisor",
+  "scopeNote": "Use primarily for thesis advisor.",
+  "type": "metadatafield"
+}
+```
+
+
+When using /api/core/metadatafields/name/dc.title, it will only return the field without a qualifier
+
+Exposed links:
+* schema: the metadata schema to which the item belongs
+
+Return codes:
+* 200 OK - if the field exists
+* 404 Not found - if the field doesn't exist
 
 ## Linked entities
 ### Schema


### PR DESCRIPTION
This is related to https://github.com/DSpace/DSpace/pull/2899#discussion_r462135920

For the front end validation on whether or not a filled in mdField is valid (on the edit item > metadata page) an exact retrieval of a mdField is needed, where either exactly one matching mdField is given or none if it doesn’t exist.

The findByName endpoint is far from ideal for this, it would have the drawbacks:
* For mdFields without a qualifier, it would need to be handled separately to determine there's no qualifier
* In frontend, it would need to be specified there's no qualifier
* Based the search results, the field has to be searched for, and no match implies it doesn't exist

For these use cases, the recommended Spring REST solution would be to create a separate non-search endpoint, retrieving the field based on the unique alternative ID, and responding with 404 if it doesn't exist