### PR TITLE
[Process] Add creation time to the process rest output

### DIFF
--- a/processes-endpoint.md
+++ b/processes-endpoint.md
@@ -22,6 +22,7 @@ This endpoint will return a list of all created processes. The JSON response doc
         "processId" : "1",
         "userId" : "aa0263e2-b90a-4528-89fa-116ea4859de1",
         "startTime" : "2017-11-22T10:29:11Z",
+        "creationTime" : "2017-11-22T10:29:00Z",
         "endTime" : null,
         "scriptName": "metadata-import",
         "processStatus" : "RUNNING",
@@ -53,7 +54,8 @@ This endpoint will return a list of all created processes. The JSON response doc
       {
         "processId" : "2",
         "userId" : "c7d85e7f-63e5-4bc0-96cb-5d80be48d62e",
-        "startTime" : "2017-11-20T10:29:11Z",
+        "startTime" : "2017-11-20T10:29:11Z",  
+        "creationTime" : "2017-11-22T10:29:00Z",
         "endTime" : "2017-11-20T10:30:11Z",
         "scriptName": "metadata-import",
         "processStatus" : "FAILED",
@@ -98,7 +100,8 @@ This endpoint will return details on the requested process.
 {
   "processId" : "3",
   "userId" : "aa0263e2-b90a-4528-89fa-116ea4859de1",
-  "startTime" : "2017-11-22T10:29:11Z",
+  "startTime" : "2017-11-22T10:29:11Z",  
+  "creationTime" : "2017-11-22T10:29:00Z",
   "endTime" : null,              
   "scriptName": "metadata-import",
   "processStatus" : "RUNNING",


### PR DESCRIPTION
This PR contains a small change to the "process" object output in rest. Currently the process only outputs the start and end time. But if multiple processes get queued, they don’t have a start or end time, so it’s difficult for a user to know when they were added or in what order. We already track the creation time in the database, this PR exposes it via the rest api.