### PR TITLE
Add search exposed config endpoint

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -26,8 +26,7 @@ For example:
 * 404 Not found - if the property doesn't exist or isn't configured to be exposed
 
 ## Search methods
-### top
-**/api/config/properties/search/exposed**
+**/api/config/properties/search/isExposed**
 
 The supported parameters are:
 * page, size [see pagination](README.md#Pagination)

--- a/configuration.md
+++ b/configuration.md
@@ -3,7 +3,7 @@
 ## Main Endpoint
 **/api/config/properties**   
 
-As we don't have yet an use case to iterate over all the configuration properties the main endpoint is not implemented and a 405 error code is returned according to our [general error response codes](README.md#Error codes).
+As we don't have yet an use case to iterate over all the configuration properties the main endpoint is not implemented and a 405 error code is returned according to our [general error response codes](README.md#Error-Codes).
 
 ## Single property
 **/api/config/properties/<:property>**
@@ -11,6 +11,7 @@ As we don't have yet an use case to iterate over all the configuration propertie
 This endpoint provides functionality to retrieve certain (configurable) configuration properties. 
 The DSpace server will have a whitelist of properties that can be retrieved by this endpoint.
 
+For example:
 
 ```json
 {
@@ -21,5 +22,40 @@ The DSpace server will have a whitelist of properties that can be retrieved by t
 }
 ```          
 
-* 200 OK - if the operation succeed
-* 404 Not found - if the property doesn't exist or isn't configured to be retrieved
+* 200 OK - if the operation succeeded
+* 404 Not found - if the property doesn't exist or isn't configured to be exposed
+
+## Search methods
+### top
+**/api/config/properties/search/exposed**
+
+The supported parameters are:
+* page, size [see pagination](README.md#Pagination)
+
+This endpoint returns all exposed configuration variables.
+
+For example:
+
+```json
+[{
+  "name": "google.analytics.key",
+  "values": [ 
+      "UA-XXXXXX-X"
+   ]
+},
+{
+  "name": "websvc.opensearch.autolink",
+  "values": [ 
+      true
+   ]
+},
+{
+  "name": "orcid.authorize-url",
+  "values": [ 
+      "https://sandbox.orcid.org/oauth/authorize"
+   ]
+}]
+```
+
+* 200 OK - if the operation succeeded
+* 404 Not found - if no property is configured to be exposed


### PR DESCRIPTION
Fixes https://github.com/DSpace/DSpace/issues/9056 as discussed in DevMtgs [14th](https://wiki.lyrasis.org/display/DSPACE/2023-09-14+DSpace+Developers+Meeting) and [21st September 2023](https://wiki.lyrasis.org/display/DSPACE/2023-09-21+DSpace+Developers+Meeting).

This PR adds an endpoint to the configuration endpoint to more efficiently share configuration with the frontend.

## Current approach

Add the **/api/config/properties/search/exposed** endpoint, as per [the top communities search endpoint](communities.md#top).

**Pros**
API endpoint url is clear.

**Cons**
Endpoint url is not consistent with the single case, **/api/config/properties/<:property>**.

## Alternative approach

I am a little undecided about whether I feel **/api/config/properties**  would be a better solution and just implementing the missing [findAll method](https://github.com/atmire/DSpace/blob/a7aeb102d4d714c26d9d4a138088cc40f1df1bef/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ConfigurationRestRepository.java#L71-L73). 

**Pros**
There is consistency in the naming of the endpoints. **/api/config/properties/<:property>** for a single configuration and **/api/config/properties/** for every single one.

**Cons**
It might not be apparent that this endpoint is limited to whitelisted, exposed configuration.