### PR TITLE
Document new `extendsType` property for custom submission steps

### DIFF
--- a/submissionsections.md
+++ b/submissionsections.md
@@ -14,25 +14,28 @@ Example: to be provided
 ## Single Submission-Definition
 **/api/config/submissionsections/<:section-name>**
 
-Provide detailed information about a specific submission-section. The JSON response document is as follow
+Provide detailed information about a specific submission-section. The JSON response document is as follows
+
 ```json
 {
-  	id: "id-of-the-submission-form-page",
-  	header: "First page",
-  	mandatory: true,
-  	sectionType: "submission-form",
-  	scope: null,
-  	type: "submissionsection",
-  	_links: {
-  		"config" : "<dspace-url>/config/submissionforms/<:id-of-the-submission-form-page>" 
-  	}
+  "id": "id-of-the-submission-form-page",
+  "header": "First page",
+  "mandatory": true,
+  "sectionType": "submission-form",
+  "extendsType": null,
+  "scope": null,
+  "type": "submissionsection",
+  "_links": {
+    "config": "<dspace-url>/config/submissionforms/<:id-of-the-submission-form-page>"
+  }
 }
 ```
 
 * the *header* attribute is the label or the i18n key to use to present the section to the user
 * the *mandatory* attribute defines if the section MUST be used by each submission. Otherwise, the user is allowed to enable/disable the section interacting with the workspaceitem
 * the *scope* attribute can be null or one of the values: workflow or submission. A value other than *null* mean that the section will be only available during the specified phase 
-* the *sectionType* attribute defines the kind of section that the UI will need to use to interact with the data. See the [documentation about the available values for sectionType provided here](submissionsection-types.md)
+* the *sectionType* attribute defines the _specific_ kind of section that the UI will need to use to interact with the data. See the [documentation about the available values for sectionType provided here](submissionsection-types.md)
+* the optional *extendsType* attribute defines the _generic_ kind of this section. For example, it is possible to implement an `custom-upload` section type that still inherits the behaviour of standard upload by specifying `"extendsType": "upload"`.
 
 
 ## Linked Entities


### PR DESCRIPTION
This PR adds an explanation of the new `extendsType` property on the `submissionsections` endpoint.
(along with some minor typo & JSON formatting fixes nearby)

Related to https://github.com/DSpace/DSpace/issues/9486
Implemented in https://github.com/DSpace/DSpace/pull/9489 and https://github.com/DSpace/dspace-angular/pull/2971