### PR TITLE
New Collections findBySubmissionDefinitionName endpoint 

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -187,6 +187,23 @@ Return codes:
 * 200 OK - if the operation succeeds
 * 401 Unauthorized - if you are not authenticated
 
+#### findBySubmissionDefinitionName
+**/api/core/collections/search/findBySubmissionDefinitionName**
+
+Get the list of all collections associated with a particular submission name.
+
+The supported parameters are:
+* `name`: the name for a specific submission-definition.
+* `page`, `size` [see pagination](README.md#Pagination)
+
+eg:
+/api/core/collections/search/findBySubmissionDefinitionName?name=<:definition-name>
+
+Return codes:
+* 200 OK - if the operation succeeds
+* 400 Bad Request - if the name is missing or invalid
+* 401 Unauthorized - if you are not authenticated
+
 ## Patch operations
 
 Collection metadata can be modified as described in [Modifying metadata via Patch](metadata-patch.md).

--- a/submissiondefinitions.md
+++ b/submissiondefinitions.md
@@ -24,7 +24,6 @@ Provide detailed information about a specific submission-definition. The JSON re
 ```
 
 Exposed links:
-* collections: list of collections that explicitly use such submission-definition
 * sections: list of submission-section included in this definition
 
 ### Search methods
@@ -34,11 +33,6 @@ Exposed links:
 It returns the submission definition that apply to a specific collection eventually fallback to the default configuration 
 
 ### Linked entities
-#### collections
-**/api/config/submissiondefinitions/<:definition-name>/collections**
-
-It returns the list of collection that make an explicit use of the submission-definition. If a collection doesn't specify the submission-definition to be used the default mapping apply but this collection is not included in the list returned by this method
-
 #### sections
 **/api/config/submissiondefinitions/<:definition-name>/sections**
 


### PR DESCRIPTION
This PR is related with issue https://github.com/DSpace/DSpace/issues/10750

It kind of relocates an existing endpoint at SubmissionDefinitions. An endpoint for returning collections based on a submission definition name. This endpoint is moved to collections. The ability to embed collections at SubmissionDefinitions levels is removed.