### PR TITLE
Add new search operations to retrieve a list of DSOs based on specific permissions

### DIFF
--- a/collections.md
+++ b/collections.md
@@ -158,7 +158,7 @@ Return codes:
 The supported parameters are:
 * page, size [see pagination](README.md#Pagination)
 * uuid: mandatory, the uuid of the community
-* entityType: mandatory, the label of the entity type  field the collection must have
+* entityType: mandatory, the label of the entity type field the collection must have
 
 It returns the list of collections where the current user is authorized to submit and deal with the request entity type
 
@@ -176,6 +176,21 @@ Return codes:
 **/api/core/collections/search/findAdminAuthorized**
 
 Get the list of all collections the current user is admin for.
+
+The supported parameters are:
+* `query`: limit the returned collections to those with metadata values matching the query terms.
+  The query is also used to build a prefix query. It can be used to implement
+  an autosuggest feature over the collection name
+* `page`, `size` [see pagination](README.md#Pagination)
+
+Return codes:
+* 200 OK - if the operation succeeds
+* 401 Unauthorized - if you are not authenticated
+
+#### findEditAuthorized
+**/api/core/collections/search/findEditAuthorized**
+
+Get the list of all collections the current user is authorized to edit.
 
 The supported parameters are:
 * `query`: limit the returned collections to those with metadata values matching the query terms.

--- a/communities.md
+++ b/communities.md
@@ -299,6 +299,36 @@ Return codes:
 * 200 OK - if the operation succeeds
 * 401 Unauthorized - if you are not authenticated
 
+#### findEditAuthorized
+**/api/core/communities/search/findEditAuthorized**
+
+Get the list of all communities the current user is authorized to edit.
+
+The supported parameters are:
+* `query`: limit the returned communities to those with metadata values matching the query terms.
+  The query is also used to build a prefix query. It can be used to implement
+  an autosuggest feature over the community name
+* `page`, `size` [see pagination](README.md#Pagination)
+
+Return codes:
+* 200 OK - if the operation succeeds
+* 401 Unauthorized - if you are not authenticated
+
+#### findAddAuthorized
+**/api/core/communities/search/findAddAuthorized**
+
+Get the list of all communities the current user is authorized to add collections or communities to.
+
+The supported parameters are:
+* `query`: limit the returned communities to those with metadata values matching the query terms.
+  The query is also used to build a prefix query. It can be used to implement
+  an autosuggest feature over the community name
+* `page`, `size` [see pagination](README.md#Pagination)
+
+Return codes:
+* 200 OK - if the operation succeeds
+* 401 Unauthorized - if you are not authenticated
+
 ## Creating communities
 
 ### Creating top level community

--- a/items.md
+++ b/items.md
@@ -606,6 +606,22 @@ Return codes:
 * 403 Forbidden - if you are not logged in with sufficient permissions
 * 404 Not found - if the item doesn't exist (or was already deleted)
 
+## Search methods
+#### findEditAuthorized
+**GET /api/core/items/search/findEditAuthorized**
+
+It returns the list of Items that the current user is authorized to edit
+
+The supported parameters are:
+* `query`: limit the returned Items to those with metadata values matching the query terms.
+  The query is also used to build a prefix query. It can be used to implement
+  an autosuggest feature over the collection name
+* `page`, `size` [see pagination](README.md#Pagination)
+
+Return codes:
+* 200 OK - if the operation succeeds
+* 401 Unauthorized - if you are not authenticated
+
 ### findByCustomURL
 
 **GET /api/core/items/search/findByCustomURL?q=<:custom-url>**


### PR DESCRIPTION
Related to DSpace/DSpace#11646
9x port: #325

Add new search endpoints, `findEditAuthorized` and `findAddAuthorized`, to retrieve lists of collections, communities, and items based on the current user's edit or add permissions.