### PR TITLE
Fix and update item request API documentation

### DIFF
--- a/item-requests.md
+++ b/item-requests.md
@@ -72,7 +72,7 @@ Return codes:
 ## Creating a Request
 **POST /api/tools/itemrequests**
 
-Anyone may create an item request. The Content-Type is JSON.  
+Anyone may create an item request (depending on backend configuration parameter `request.item.type`). The Content-Type is JSON.  
 
 Example JSON payload:
 

--- a/item-requests.md
+++ b/item-requests.md
@@ -72,7 +72,10 @@ Return codes:
 ## Creating a Request
 **POST /api/tools/itemrequests**
 
-Anyone may create an item request.  The Content-Type is JSON.  Example:
+Anyone may create an item request. The Content-Type is JSON.  
+
+Example JSON payload:
+
 ```json
 {
     "itemId": "71d9fb0c-cc36-41c1-b1d3-63887b414fca",
@@ -83,7 +86,11 @@ Anyone may create an item request.  The Content-Type is JSON.  Example:
     "requestMessage": "Please send this to me."
 }
 ```
-`bitstreamId` is ignored and may be omitted if `allfiles` is `false`.  `requestMessage` is optional.  `requestEmail` and `requestName` are ignored and may be omitted if the session is authenticated -- these fields will be filled from the session user's EPerson.  If the session is anonymous then `requestEmail` is required.  `bitstreamId` is required if `allfiles` is false.  `itemId` is always required.
+
+* `bitstreamId` is ignored and may be omitted if `allfiles` is `true`. `bitstreamId` is required if `allfiles` is false.
+* `itemId` is always required.
+* `requestMessage` is optional.
+* `requestEmail` and `requestName` are ignored and may be omitted if the session is authenticated -- these fields will be filled from the session user's EPerson. If the session is anonymous then `requestEmail` is required.
 
 The response is empty, generated token should not be exposed.
 


### PR DESCRIPTION
There was a small error in the description of the `bitstreamId` parameter. It is only ignored (and can also be omitted) when `allfiles` is set to **true** (and not, as described, to false).

Additionally, this PR improves the formatting and highlights the backend configuration setting `request.item.type`, which determines which permission is required for creating new item requests.