### PR TITLE
[GitHub Actions] Resync all defined actions with those on DSpace/DSpace.  Add the "stale" action.

### DIFF
--- a/.github/workflows/issue_opened.yml
+++ b/.github/workflows/issue_opened.yml
@@ -8,7 +8,7 @@ on:
 permissions: {}
 jobs:
   automation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     # Add the new issue to a project board, if it needs triage
     # See https://github.com/actions/add-to-project
@@ -16,7 +16,7 @@ jobs:
       # Only add to project board if issue is flagged as "needs triage" or has no labels
       # NOTE: By default we flag new issues as "needs triage" in our issue template
       if: (contains(github.event.issue.labels.*.name, 'needs triage') || join(github.event.issue.labels.*.name) == '')
-      uses: actions/add-to-project@v0.5.0
+      uses: actions/add-to-project@v2
       # Note, the authentication token below is an ORG level Secret. 
       # It must be created/recreated manually via a personal access token with admin:org, project, public_repo permissions
       # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token

--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -18,7 +18,7 @@ jobs:
   triage:
     # Ensure this job never runs on forked repos. It's only executed for 'DSpace/RestContract'
     if: github.repository == 'dspace/restcontract'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/port_merged_pull_request.yml
+++ b/.github/workflows/port_merged_pull_request.yml
@@ -18,16 +18,23 @@ permissions:
 
 jobs:
   port_pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     # Don't run on closed *unmerged* pull requests
     if: github.event.pull_request.merged
     steps:
       # Checkout code
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
+        with:
+          # When using 'pull_request_target' (see above), this 'checkout' step will always fail because it
+          # may make the codebase vulnerable to "pwn requests" via the user-created PR.
+          # See https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
+          # However, we are allowing this unsafe checkout because (1) it's required to backport the PR, and
+          # (2) this job only runs when a PR is MERGED, and merger only happens after a thorough review of the PR.
+          allow-unsafe-pr-checkout: true
       # Port PR to other branch (ONLY if labeled with "port to")
       # See https://github.com/korthout/backport-action
       - name: Create backport pull requests
-        uses: korthout/backport-action@v2
+        uses: korthout/backport-action@v4
         with:
           # Trigger based on a "port to [branch]" label on PR
           # (This label must specify the branch name to port to)

--- a/.github/workflows/pull_request_opened.yml
+++ b/.github/workflows/pull_request_opened.yml
@@ -16,9 +16,9 @@ permissions:
 
 jobs:
   automation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
     # Assign the PR to whomever created it. This is useful for visualizing assignments on project boards
     # See https://github.com/toshimaru/auto-author-assign
     - name: Assign PR to creator
-      uses: toshimaru/auto-author-assign@v2.0.1
+      uses: toshimaru/auto-author-assign@v3.0.3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,70 @@
+# DSpace rules for flagging untouched issues and PRs as stale using 'stale':
+# https://github.com/actions/stale
+name: 'Mark issues and PRs as stale'
+on:
+  # Schedule to run weekly on Sunday at 2:03am UTC
+  schedule:
+    - cron: '3 2 * * 0'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/stale@v10
+        with:
+          # Number of GitHub API calls to allow in a single run (to avoid hitting GitHub's rate limit)
+          # Default is 30. But, we've found that only results in processing ~7 issues or PRs. So, we've increased it.
+          operations-per-run: 60
+          # Issues will be marked stale after 3 years of no activity
+          days-before-issue-stale: 1095
+          # Issues marked stale will be closed after one additional week of no activity
+          days-before-issue-close: 7
+          # High priority issues are never marked stale
+          exempt-issue-labels: 'high priority'
+          # When an issue is marked stale, this label and comment will be added to the issue.
+          stale-issue-label: stale
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had
+            activity in 3 years. It will be closed in 7 days if no further activity occurs.
+
+            Allowing issues to close as stale helps us filter out issues which can wait
+            for future development time. All issues closed by this bot will continue to act 
+            like normal issues; they can be searched for, commented on or reopened at any point.
+
+            To extend the lifetime of an issue please comment below. This will help us to see
+            that this issue is still affecting you with current versions of DSpace, and encourage
+            us to re-prioritize this issue.
+          # When an issue is closed, this comment will be added to the issue.
+          close-issue-message: |
+            This issue has been closed automatically as "stale". If this still affects you please 
+            request to re-open this issue via a comment, providing us with details on how this still
+            impacts your usage of DSpace.
+          # PRs will be marked stale after 1 year of no activity
+          days-before-pr-stale: 365
+          # PRs marked stale will be closed after two additional weeks of no activity
+          days-before-pr-close: 14
+          # High priority PRs are never marked stale
+          exempt-pr-labels: 'high priority'
+          # When a PR is marked stale, this label and comment will be added to the issue.
+          stale-pr-label: stale
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had
+            activity in one year. It will be closed in 14 days if no further activity occurs.
+
+            Allowing pull requests to close as stale helps us filter out old work that is no longer
+            relevant and helps developers focus on reviewing current work.
+
+            All pull requests closed by this bot act like normal pull requests;
+            they can be searched for, commented on or reopened at any point.
+
+            If these changes are still relevant then please comment and/or rebase your PR based on the
+            latest DSpace code. This will remove the stale status and notify us to assign a reviewer
+            for your PR.
+          close-pr-message: |
+            This pull request has been closed automatically. If these changes are still relevant
+            then please re-open this pull request with a comment and rebase your PR based on the latest
+            DSpace code. This will notify us to assign a reviewer to your PR.


### PR DESCRIPTION
## Description

This PR "resyncs" the GitHub actions in this RestContract repository with those in `DSpace/DSpace`.  This includes the addition of the `stale` action (to check for stale PRs or issue tickets).

Because this RestContract repository doesn't have dependabot auto-updating these actions, it's important to resync them occasionally.  (Because the number of actions are fewer in this repo, I think it's OK to leave dependabot disabled for now...as GitHub actions don't really require frequent updates.)

(NOTE: This PR should not need to be backported, as having the older branches running older versions of these actions should not be problematic)