### PR TITLE
replace demo7 subdomain in example URLs

### DIFF
--- a/bitstreams.md
+++ b/bitstreams.md
@@ -236,7 +236,7 @@ Return codes:
 A sample `curl` command to delete two bitstreams in a single `PATCH` request would be:
 
 ```sh
-curl -i -X PATCH https://demo7.dspace.org/server/api/core/bitstreams \
+curl -i -X PATCH https://demo.dspace.org/server/api/core/bitstreams \
      -H 'Authorization: Bearer …' \
      -H 'content-type: application/json' \
      --data '[ { "op": "remove", "path": "/bitstreams/12623672-25a9-4df2-ab36-699c4c240c7e"}, { "op": "remove", "path": "/bitstreams/5a3f7c7a-d3df-419c-8a2-f00ede62c60a"}]'

--- a/statistics-viewevents.md
+++ b/statistics-viewevents.md
@@ -29,7 +29,7 @@ The sections below describe the parameters for a page view event. All other info
 {
   "targetId": "43f9bb3e-f90d-458f-9858-7e4589481d18",
   "targetType": "item",
-  "referrer": "https://demo7.dspace.org/search"
+  "referrer": "https://demo.dspace.org/search"
 }
 ```
 

--- a/versionhistories.md
+++ b/versionhistories.md
@@ -30,13 +30,13 @@ Provide information about for a version history id.
   "type": "versionhistory",  
   "_links": {
     "self": {
-      "href": "https://demo7.dspace.org/server/api/versioning/versionhistories/1"
+      "href": "https://demo.dspace.org/server/api/versioning/versionhistories/1"
     },
     "versions": {
-      "href": "https://demo7.dspace.org/server/api/versioning/versionhistories/1/versions"
+      "href": "https://demo.dspace.org/server/api/versioning/versionhistories/1/versions"
     },
     "draftVersion": {
-      "href": "https://demo7.dspace.org/server/api/versioning/versionhistories/1/draftVersion"
+      "href": "https://demo.dspace.org/server/api/versioning/versionhistories/1/draftVersion"
     }
   }
 }
@@ -81,7 +81,7 @@ Only versions related to archived or withdrawn items are return, the most recent
     ],
     "_links": {
      "self": {
-       "href": "https://demo7.dspace.org/server/api/versioning/versions/search/findByHistory?historyId=1"
+       "href": "https://demo.dspace.org/server/api/versioning/versions/search/findByHistory?historyId=1"
      }
     },
     "page": {

--- a/versions.md
+++ b/versions.md
@@ -32,9 +32,9 @@ The new created version will be returned in the response, see the [get single ve
 An example curl call:
 
 ```
- curl -i -X POST https://demo7.dspace.org/server/api/versioning/versions \
+ curl -i -X POST https://demo.dspace.org/server/api/versioning/versions \
  -H "Content-Type:text/uri-list" \
- --data "https://demo7.dspace.org/server/api/core/items/a8ba963f-d9c9-4198-b5a4-3f74e2ab6fb9"
+ --data "https://demo.dspace.org/server/api/core/items/a8ba963f-d9c9-4198-b5a4-3f74e2ab6fb9"
 ```
 
 Status codes:
@@ -61,13 +61,13 @@ The following example shows all the available attributes as exposed to an admini
   "submitterName": "LastName, FirstName",
   "_links": {
     "versionhistory": {
-      "href": "https://demo7.dspace.org/server/api/versioning/versionhistories/1"
+      "href": "https://demo.dspace.org/server/api/versioning/versionhistories/1"
     },
     "self": {
-      "href": "https://demo7.dspace.org/server/api/versioning/versions/345"
+      "href": "https://demo.dspace.org/server/api/versioning/versions/345"
     },
     "item": {
-      "href": "https://demo7.dspace.org/server/api/versioning/versions/345/item"
+      "href": "https://demo.dspace.org/server/api/versioning/versions/345/item"
     }
   }
 }         


### PR DESCRIPTION
This pull request updates several example URLs in the documentation to use the current `demo.dspace.org` domain instead of the outdated `demo7.dspace.org`.