### PR TITLE
Document Location headers for created REST resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This type of endpoint interacts with a group (or collection) of resources (objec
 - `POST` -
 Creates a new resource (object) and adds it to the group. Any required data (i.e. attributes) for the new object _must be included_ in the request body. An empty request body is not allowed, unless you are creating an empty object with no attributes.
     - Related or additional information (such as required associations to other objects) may be passed as querystring parameters in the request, _if it is required to create the object._
+    - A successful JSON creation returns `201 Created` with a `Location` response header containing the absolute URI of the created resource.
         ```
         # For example, creating a Collection *requires* linking it to a parent Community
         # In this scenario, we must have a querystring param to specify the parent Community UUID

--- a/epersons.md
+++ b/epersons.md
@@ -231,6 +231,9 @@ To create a new EPerson, perform a post with the JSON below to the epersons endp
 }
 ```
 
+A successful response includes a `Location` header with the canonical URI of the created EPerson:
+`${dspace.url}/api/eperson/epersons/<:uuid>`.
+
 Status codes:
 * 201 Created - if the operation succeed
 * 401 Unauthorized - if you are not authenticated

--- a/epersons.md
+++ b/epersons.md
@@ -276,6 +276,9 @@ The "eperson.firstname" and "eperson.lastname" metadata are mandatory. The phone
 The email property can be set, but would need to be identical to the value from the registration.  
 The selfRegistered property can be set, but would need to be true
 
+A successful response includes a `Location` header with the canonical URI of the created EPerson:
+`${dspace.url}/api/eperson/epersons/<:uuid>`.
+
 Status codes:
 * 201 Created - if the operation succeed
 * 400 Bad Request - if the email address didn't match the token or already exists. If the token doesn't exist or is expired
@@ -303,6 +306,9 @@ curl -X POST http://${dspace.url}/api/eperson/epersons/${id-eperson}?token=${tok
 ```
 
 As you can see, the request has an ***empty body***.
+
+A successful response includes a `Location` header with the canonical URI of the updated EPerson:
+`${dspace.url}/api/eperson/epersons/<:uuid>`.
 
 Status codes:
 * 201 Created - if the operation succeed


### PR DESCRIPTION
## References

- Related to DSpace/DSpace#8881
- Companion to DSpace/DSpace#12848

## Description

Document that successful JSON collection-resource creation returns `201 Created` with an absolute `Location` header for the created resource.

The EPerson creation contract now includes the concrete canonical URI shape returned by `POST /api/eperson/epersons`.

## Validation

- `git diff --check`
- Verified the documented EPerson URI matches the backend integration assertion in DSpace/DSpace#12848.